### PR TITLE
[WIP] Chemfiles 0.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ using Chemfiles
 trajectory = Trajectory("filename.xyz")
 frame = read(trajectory)
 
-println("There are $(natoms(frame)) atoms in the frame")
+println("There are $(size(frame)) atoms in the frame")
 positions = positions(frame)
 
 # Do awesome things with the positions here !

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -46,6 +46,10 @@ These functions are not exported, and should be called by there fully qualified 
 
     Set the current log level to ``level``.
 
+.. jl:function:: Chemfiles.set_warning_callback(callback)
+
+    Set the global warning `callback` to be used for each warning event.
+
  The following logging levels are available:
 
 - ``Chemfiles.ERROR``: Only log errors;
@@ -206,6 +210,17 @@ the types of informations, some fields may be initialized to a default value. A
     Add velocities to this `Frame`_. The storage is initialized with the result of
     ``size(frame)`` as number of atoms. If the frame already have velocities, this
     does nothing.
+
+.. jl:function:: add_atom!(frame::Frame, atom::Atom, position::Array{Float64}, velocity::Array{Float64})
+
+    Add an `atom` and the corresponding `position` and `velocity` data to a `frame`.
+    `velocity` can be `NULL` if no velocity is associated with the atom.
+
+.. jl:function:: remove_atom!(frame::Frame, index::Integer)
+
+    Remove the `atom` at `index` in the frame.
+    This modify all the `atoms` indexes after `index`, and invalidate any pointer
+    obtained using `positions`_ or `velocities`_.
 
 .. jl:function:: has_velocities(frame::Frame) -> Bool
 
@@ -368,6 +383,29 @@ in the system, together with the list of bonds these atoms forms.
 
     Remove any existing bond between the atoms ``i`` and ``j`` in the system.
 
+.. jl:function:: add_residue!(topology::Topology, residue::Residue)
+
+   Add a copy of `residue` to this `topology`.
+   The residue id must not already be in the topology, and the residue must
+   contain only atoms that are not already in another residue.
+
+.. jl:function:: count_residue(topology::Topology)
+
+   Get the number of residues in the `topology`.
+
+.. jl:function:: are_linked(topology::Topology, first::Residue, second::Residue)
+
+   Check if the two residues `first` and `second` from the `topology` are
+   linked together, *i.e.* if there is a bond between one atom in the first
+   residue and one atom in the second one.
+
+.. jl:function:: resize!(topology::Topology, natoms::Integer)
+
+   Resize the `topology` to hold `natoms` atoms. If the new number of atoms is
+   bigger than the current number, new atoms will be created with an empty name
+   and type. If it is lower than the current number of atoms, the last atoms
+   will be removed, together with the associated bonds, angles and dihedrals.
+
 .. _Atom:
 
 ``Atom`` type and associated function
@@ -447,6 +485,56 @@ The following atom types are available:
 - ``Chemfiles.DUMMY_ATOM``: Dummy site, with no physical reality
 - ``Chemfiles.UNDEFINED_ATOM``: Undefined atom type
 
+.. _Residue:
+
+``Residue`` type and associated function
+------------------------------------------
+
+.. jl:function:: Residue(name::String, resid::Integer)
+
+    Create a new residue with the given `name` and residue identifier `resid`.
+
+.. jl:function:: Residue(name::String)
+
+    Create a new residue with the given `name`.
+
+.. jl:function:: Residue(topology::Topology, index::Integer)
+
+    Get a copy of the residue at `index` from a `topology`.
+    If `index` is bigger than the result of `count_residues`, this function will return `nothing`.
+    The residue index in the topology is not always the same as the residue `id`.
+
+.. jl:function:: residue_for_atom(topology::Topology, index::Integer)
+
+    Get a copy of the residue containing the atom at `index` in the `topology`.
+    This function will return `nothing` if the atom is not in a residue, or if the
+    `index` is bigger than `natoms`.
+
+.. jl:function:: name(residue::Residue)
+
+    Get the name of a `residue`.
+
+.. jl:function:: id(residue::Residue)
+
+    Get the identifier of a `residue` in the initial topology.
+
+.. jl:function:: id(residue::Residue)
+
+    Get the identifier of a `residue` in the initial topology.
+
+.. jl:function:: natoms(residue::Residue)
+
+    Get the number of atoms in a `residue`.
+
+.. jl:function:: add_atom!(residue::Residue, i::Integer)
+
+    Add the atom at index `i` in the `residue`.
+
+.. jl:function:: contains!(residue::Residue, i::Integer)
+
+    Check if the atom at index `i` is in the `residue`.
+
+
 .. _Selection:
 
 ``Selection`` type and associated function
@@ -466,3 +554,7 @@ information about the selection language.
 
     Evaluate a `Selection`_ on a given `Frame`_. This function return a list of
     indexes or tuples of indexes of atoms in the frame matching the selection.
+
+.. jl:function:: selection_string(selection::Selection)
+
+    Get the selection string used to create a given `selection`.

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -42,10 +42,6 @@ These functions are not exported, and should be called by there fully qualified 
 
     Get the current log level.
 
-.. jl:function:: Chemfiles.set_loglevel(level)
-
-    Set the current log level to ``level``.
-
 .. jl:function:: Chemfiles.set_warning_callback(callback)
 
     Set the global warning `callback` to be used for each warning event.
@@ -174,10 +170,6 @@ the types of informations, some fields may be initialized to a default value. A
 
     Create an empty `Frame`_ with initial capacity of ``natoms``. It will be
     automatically resized if needed.
-
-.. jl:function:: natoms(frame::Frame) -> Integer
-
-    Get the `Frame`_ size, i.e. the current number of atoms
 
 .. jl:function:: size(frame::Frame) -> Integer
 
@@ -324,10 +316,6 @@ in the system, together with the list of bonds these atoms forms.
     Extract the `Topology`_ from a frame.
 
 .. jl:function:: size(topology::Topology)
-
-    Get the `Topology`_ size, i.e. the current number of atoms.
-
-.. jl:function:: natoms(topology::Topology)
 
     Get the `Topology`_ size, i.e. the current number of atoms.
 
@@ -522,7 +510,7 @@ The following atom types are available:
 
     Get the identifier of a `residue` in the initial topology.
 
-.. jl:function:: natoms(residue::Residue)
+.. jl:function:: size(residue::Residue)
 
     Get the number of atoms in a `residue`.
 

--- a/examples/indexes.jl
+++ b/examples/indexes.jl
@@ -8,10 +8,9 @@ using Chemfiles
 traj = Trajectory("filename.xyz")
 frame = read(traj)
 pos = positions(frame)
-
 indexes = Int[]
 
-for i=1:natoms(frame)
+for i=1:size(frame)
     if pos[1, i] < 5
         push!(indexes, i)
     end

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -19,7 +19,7 @@ module Chemfiles
 
     include("errors.jl")
 
-    export Trajectory, Topology, Atom, UnitCell, Frame, Selection
+    export Trajectory, Topology, Atom, UnitCell, Frame, Selection, Residue
 
     function version()
         unsafe_string(lib.chfl_version())
@@ -94,10 +94,21 @@ module Chemfiles
         end
     end
 
+    type Residue
+        handle :: Ptr{lib.CHFL_RESIDUE}
+        function Residue(ptr::Ptr{lib.CHFL_RESIDUE})
+            check(ptr)
+            this = new(ptr)
+            finalizer(this, free)
+            return this
+        end
+    end
+
     include("Atom.jl")
     include("Frame.jl")
     include("Topology.jl")
     include("Trajectory.jl")
     include("UnitCell.jl")
     include("Selection.jl")
+    include("Residue.jl")
 end

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export positions, velocities, add_atom!, remove_atom!, add_velocities!, has_velocities, set_cell!,
-set_topology!, set_step!, guess_bonds!, natoms
+set_topology!, set_step!, guess_bonds!
 
 function Frame()
     handle = lib.chfl_frame()
@@ -16,15 +16,13 @@ function free(frame::Frame)
     lib.chfl_frame_free(frame.handle)
 end
 
-function natoms(frame::Frame)
+function Base.size(frame::Frame)
     n = Ref{UInt64}(0)
     check(
         lib.chfl_frame_atoms_count(frame.handle, n)
     )
     return n[]
 end
-
-Base.size(frame::Frame) = natoms(frame)
 
 function Base.resize!(frame::Frame, size::Integer)
     check(

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-export positions, velocities, add_velocities!, has_velocities, set_cell!,
+export positions, velocities, add_atom!, remove_atom!, add_velocities!, has_velocities, set_cell!,
 set_topology!, set_step!, guess_bonds!, natoms
 
 function Frame()
@@ -96,5 +96,19 @@ end
 
 function guess_bonds!(frame::Frame)
     check(lib.chfl_frame_guess_topology(frame.handle))
+    return nothing
+end
+
+function add_atom!(frame::Frame, atom::Atom, position::Array{Float64}, velocity::Array{Float64})
+    check(
+        lib.chfl_frame_add_atom(frame.handle, atom.handle, position, velocity)
+    )
+    return nothing
+end
+
+function remove_atom!(frame::Frame, index::Integer)
+    check(
+        lib.chfl_frame_remove(frame.handle, UInt64(index))
+    )
     return nothing
 end

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -1,0 +1,69 @@
+# Copyright (c) Guillaume Fraux 2015
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+export name, id, natoms, add_atom!
+
+function Residue(name::String, resid::Integer)
+    handle = lib.chfl_residue(pointer(name), UInt64(resid))
+    return Residue(handle)
+end
+
+function Residue(name::String)
+    handle = lib.chfl_residue(pointer(name), typemax(UInt64))
+    return Residue(handle)
+end
+
+function Residue(topology::Topology, index::Integer)
+    handle = lib.chfl_residue_from_topology(topology.handle, UInt64(index))
+    return Residue(handle)
+end
+
+function free(residue::Residue)
+    lib.chfl_residue_free(residue.handle)
+end
+
+function name(residue::Residue)
+    str = " " ^ 10
+    check(
+        lib.chfl_residue_name(residue.handle, pointer(str), UInt64(length(str)))
+    )
+    return strip_null(str)
+end
+
+function id(residue::Residue)
+    resid = Ref{UInt64}(0)
+    check(
+        lib.chfl_residue_id(residue.handle, resid)
+    )
+    return resid[]
+end
+
+function natoms(residue::Residue)
+    atoms = Ref{UInt64}(0)
+    check(
+        lib.chfl_residue_atoms_count(residue.handle, atoms)
+    )
+    return atoms[]
+end
+
+Base.size(residue::Residue) = natoms(residue)
+
+function add_atom!(residue::Residue, i::Integer)
+    check(
+        lib.chfl_residue_add_atom(residue.handle, UInt64(i))
+    )
+    return nothing
+end
+
+function Base.contains(residue::Residue, i::Integer)
+    res = Ref{UInt8}(0)
+    check(
+        lib.chfl_residue_contains(residue.handle, UInt64(i), res)
+    )
+    return convert(Bool, res[])
+end
+
+

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -16,9 +16,14 @@ function Residue(name::String)
     return Residue(handle)
 end
 
-function Residue(topology::Topology, index::Integer)
-    handle = lib.chfl_residue_from_topology(topology.handle, UInt64(index))
-    return Residue(handle)
+function Residue(topology::Topology, index::Integer; atom=false)
+    if atom
+        handle = lib.chfl_residue_for_atom(topology.handle, UInt64(index))
+        return Residue(handle)
+    else
+        handle = lib.chfl_residue_from_topology(topology.handle, UInt64(index))
+        return Residue(handle)
+    end
 end
 
 function free(residue::Residue)
@@ -65,5 +70,3 @@ function Base.contains(residue::Residue, i::Integer)
     )
     return convert(Bool, res[])
 end
-
-

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-export name, id, natoms, add_atom!, residue_for_atom
+export name, id, add_atom!, residue_for_atom
 
 function Residue(name::String, resid::Integer)
     handle = lib.chfl_residue(pointer(name), UInt64(resid))
@@ -47,15 +47,13 @@ function id(residue::Residue)
     return resid[]
 end
 
-function natoms(residue::Residue)
+function Base.size(residue::Residue)
     atoms = Ref{UInt64}(0)
     check(
         lib.chfl_residue_atoms_count(residue.handle, atoms)
     )
     return atoms[]
 end
-
-Base.size(residue::Residue) = natoms(residue)
 
 function add_atom!(residue::Residue, i::Integer)
     check(

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-export name, id, natoms, add_atom!
+export name, id, natoms, add_atom!, residue_for_atom
 
 function Residue(name::String, resid::Integer)
     handle = lib.chfl_residue(pointer(name), UInt64(resid))
@@ -16,15 +16,16 @@ function Residue(name::String)
     return Residue(handle)
 end
 
-function Residue(topology::Topology, index::Integer; atom=false)
-    if atom
-        handle = lib.chfl_residue_for_atom(topology.handle, UInt64(index))
-        return Residue(handle)
-    else
-        handle = lib.chfl_residue_from_topology(topology.handle, UInt64(index))
-        return Residue(handle)
-    end
+function Residue(topology::Topology, index::Integer)
+    handle = lib.chfl_residue_from_topology(topology.handle, UInt64(index))
+    return Residue(handle)
 end
+
+function residue_for_atom(topology::Topology, index::Integer)
+    handle = lib.chfl_residue_for_atom(topology.handle, UInt64(index))
+    return Residue(handle)
+end
+
 
 function free(residue::Residue)
     lib.chfl_residue_free(residue.handle)

--- a/src/Selection.jl
+++ b/src/Selection.jl
@@ -24,7 +24,7 @@ function evaluate(selection::Selection, frame::Frame)
         lib.chfl_selection_evaluate(selection.handle, frame.handle, matching)
     )
     matching = matching[]
-    matches = Array(lib.chfl_match_t, matching)
+    matches = Array{lib.chfl_match_t}(matching)
     check(
         lib.chfl_selection_matches(selection.handle, pointer(matches), matching)
     )

--- a/src/Selection.jl
+++ b/src/Selection.jl
@@ -3,11 +3,19 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-export evaluate
+export evaluate, selection_string
 
 function Selection(selection::AbstractString)
     handle = lib.chfl_selection(pointer(selection))
     return Selection(handle)
+end
+
+function selection_string(selection::Selection)
+    res = " " ^ 64
+    check(
+        lib.chfl_selection_string(selection.handle, pointer(res), UInt64(length(res)))
+    )
+    return strip_null(res)
 end
 
 function Base.size(selection::Selection)

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -93,7 +93,7 @@ end
 
 function bonds(topology::Topology)
     count = nbonds(topology)
-    res = Array(UInt64, 2, count)
+    res = Array{UInt64}(2, count)
     check(
         lib.chfl_topology_bonds(topology.handle, pointer(res), count)
     )
@@ -102,7 +102,7 @@ end
 
 function angles(topology::Topology)
     count = nangles(topology)
-    res = Array(UInt64, 3, count)
+    res = Array{UInt64}(3, count)
     check(
         lib.chfl_topology_angles(topology.handle, pointer(res), count)
     )
@@ -111,7 +111,7 @@ end
 
 function dihedrals(topology::Topology)
     count = ndihedrals(topology)
-    res = Array(UInt64, 4, count)
+    res = Array{UInt64}(4, count)
     check(
         lib.chfl_topology_dihedrals(topology.handle, pointer(res), count)
     )

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export natoms, remove!, isbond, isangle, isdihedral, nbonds, nangles, ndihedrals,
-       bonds, angles, dihedrals, add_bond!, remove_bond!
+       bonds, angles, dihedrals, add_bond!, remove_bond!, add_residue!, residues, are_linked
 
 function Topology()
     return Topology(lib.chfl_topology())
@@ -130,4 +130,27 @@ function remove_bond!(topology::Topology, i::Integer, j::Integer)
         lib.chfl_topology_remove_bond(topology.handle, UInt64(i), UInt64(j))
     )
     return nothing
+end
+
+function add_residue!(topology::Topology, residue::Residue)
+    check(
+        lib.chfl_topology_add_residue(topology.handle, residue.handle)
+    )
+    return nothing
+end
+
+function residues(topology::Topology)
+    nresidues = Ref{UInt64}(0)
+    check(
+        lib.chfl_topology_residues_count(topology.handle, nresidues)
+    )
+    return nresidues[]
+end
+
+function are_linked(topology::Topology, first::Residue, second::Residue)
+    res = Ref{UInt8}(0)
+    check(
+        lib.chfl_topology_residues_linked(topology.handle, first.handle, second.handle, res)
+    )
+    return convert(Bool, res[])
 end

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -5,7 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export natoms, remove!, isbond, isangle, isdihedral, nbonds, nangles, ndihedrals,
-       bonds, angles, dihedrals, add_bond!, remove_bond!, add_residue!, residues, are_linked
+    bonds, angles, dihedrals, add_bond!, remove_bond!, add_residue!, residues,
+    are_linked, count_residues
 
 function Topology()
     return Topology(lib.chfl_topology())
@@ -139,7 +140,7 @@ function add_residue!(topology::Topology, residue::Residue)
     return nothing
 end
 
-function residues(topology::Topology)
+function count_residues(topology::Topology)
     nresidues = Ref{UInt64}(0)
     check(
         lib.chfl_topology_residues_count(topology.handle, nresidues)

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-export natoms, remove!, isbond, isangle, isdihedral, nbonds, nangles, ndihedrals,
+export remove!, isbond, isangle, isdihedral, nbonds, nangles, ndihedrals,
     bonds, angles, dihedrals, add_bond!, remove_bond!, add_residue!, residues,
     are_linked, count_residues
 
@@ -20,15 +20,13 @@ function free(topology::Topology)
     lib.chfl_topology_free(topology.handle)
 end
 
-function natoms(topology::Topology)
+function Base.size(topology::Topology)
     n = Ref{UInt64}(0)
     check(
         lib.chfl_topology_atoms_count(topology.handle, n)
     )
     return n[]
 end
-
-Base.size(topology::Topology) = natoms(topology)
 
 function Base.push!(topology::Topology, atom::Atom)
     check(

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -154,3 +154,9 @@ function are_linked(topology::Topology, first::Residue, second::Residue)
     )
     return convert(Bool, res[])
 end
+
+function Base.resize!(topology::Topology, natoms::Integer)
+    check(
+        lib.chfl_topology_resize(topology.handle, UInt64(natoms))
+    )
+end

--- a/src/UnitCell.jl
+++ b/src/UnitCell.jl
@@ -85,7 +85,7 @@ function set_angles!(cell::UnitCell, α::Real, β::Real, γ::Real)
 end
 
 function cell_matrix(cell::UnitCell)
-    matrix = Array(Float64, 3, 3)
+    matrix = Array{Float64}(3, 3)
     check(
         lib.chfl_cell_matrix(cell.handle, pointer(matrix))
     )

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -7,8 +7,10 @@
 type ChemfilesError <: Exception
     message::AbstractString
 end
+
 Base.show(io::IO, e::ChemfilesError) = show(io, "Chemfiles error: $(e.message)")
-export ChemfilesError
+
+export ChemfilesError, ChemfilesWarning, set_warning_callback
 
 function check(result::Integer, message = "Unknown error")
     if result != 0
@@ -35,3 +37,14 @@ end
 function clear_errors()
     check(lib.chfl_clear_errors())
 end
+
+function warning_callback(message::Ptr{UInt8})
+    warn(unsafe_string(message))
+end
+
+function set_warning_callback(cb::Function)
+    callback = cfunction(cb, Void, (Ptr{UInt8},))
+    check(lib.chfl_set_warning_callback(callback))
+end
+
+set_warning_callback(warning_callback)

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -38,12 +38,13 @@ function clear_errors()
     check(lib.chfl_clear_errors())
 end
 
-function warning_callback(message::Ptr{UInt8})
-    warn(unsafe_string(message))
+function warning_callback(message::String)
+    warn("[chemfiles] ", message)
 end
 
 function set_warning_callback(cb::Function)
-    callback = cfunction(cb, Void, (Ptr{UInt8},))
+    cb_adaptor = (x) -> cb(unsafe_string(x))
+    callback = cfunction(cb_adaptor, Void, (Ptr{UInt8},))
     check(lib.chfl_set_warning_callback(callback))
 end
 

--- a/src/generated/types.jl
+++ b/src/generated/types.jl
@@ -20,8 +20,8 @@ immutable chfl_match_t
     atoms_4 ::UInt64
 end
 
-typealias Cbool Cuchar
-typealias chfl_vector_t Array{Cdouble, 1}
+const Cbool = Cuchar
+const chfl_vector_t = Array{Cdouble, 1}
 # === End of manual translation
 
 immutable CHFL_TRAJECTORY end
@@ -39,7 +39,7 @@ immutable CHFL_SELECTION end
 immutable CHFL_RESIDUE end
 
 # enum chfl_status
-typealias chfl_status UInt32
+const chfl_status = UInt32
 const CHFL_SUCCESS = chfl_status(0)
 const CHFL_MEMORY_ERROR = chfl_status(1)
 const CHFL_FILE_ERROR = chfl_status(2)
@@ -49,7 +49,7 @@ const CHFL_GENERIC_ERROR = chfl_status(5)
 const CHFL_CXX_ERROR = chfl_status(6)
 
 # enum chfl_cell_shape_t
-typealias chfl_cell_shape_t UInt32
+const chfl_cell_shape_t = UInt32
 const CHFL_CELL_ORTHORHOMBIC = chfl_cell_shape_t(0)
 const CHFL_CELL_TRICLINIC = chfl_cell_shape_t(1)
 const CHFL_CELL_INFINITE = chfl_cell_shape_t(2)

--- a/test/Atom.jl
+++ b/test/Atom.jl
@@ -1,7 +1,7 @@
 @testset "Atom Type" begin
     a = Atom("He")
 
-    @test mass(a) ≈ 4.002602
+    @test mass(a) ≈ 4.002602 atol=1e-6
     @test charge(a) == 0
     @test name(a) == "He"
     @test atom_type(a) == "He"
@@ -18,7 +18,7 @@
     @test atom_type(a) == "Zn"
     @test fullname(a) == "Zinc"
 
-    @test vdw_radius(a) ≈ 2.1
-    @test covalent_radius(a) ≈ 1.31
+    @test vdw_radius(a) ≈ 2.1 atol=1e-1
+    @test covalent_radius(a) ≈ 1.31 atol=1e-2
     @test atomic_number(a) == 30
 end

--- a/test/Atom.jl
+++ b/test/Atom.jl
@@ -1,25 +1,24 @@
-
-facts("Atom type") do
+@testset "Atom Type" begin
     a = Atom("He")
 
-    @fact mass(a) --> roughly(4.002602, 1e-6)
-    @fact charge(a) --> 0
-    @fact name(a) --> "He"
-    @fact atom_type(a) --> "He"
+    @test mass(a) ≈ 4.002602
+    @test charge(a) == 0
+    @test name(a) == "He"
+    @test atom_type(a) == "He"
 
     set_mass!(a, 678)
-    @fact mass(a) --> 678
+    @test mass(a) == 678
     set_charge!(a, -1.5)
-    @fact charge(a) --> -1.5
+    @test charge(a) == -1.5
     set_name!(a, "Zn")
-    @fact name(a) --> "Zn"
+    @test name(a) == "Zn"
 
-    @fact fullname(a) --> "Helium"
+    @test fullname(a) == "Helium"
     set_atom_type!(a, "Zn")
-    @fact atom_type(a) --> "Zn"
-    @fact fullname(a) --> "Zinc"
+    @test atom_type(a) == "Zn"
+    @test fullname(a) == "Zinc"
 
-    @fact vdw_radius(a) --> roughly(2.1, 1e-1)
-    @fact covalent_radius(a) --> roughly(1.31, 1e-2)
-    @fact atomic_number(a) --> 30
+    @test vdw_radius(a) ≈ 2.1
+    @test covalent_radius(a) ≈ 1.31
+    @test atomic_number(a) == 30
 end

--- a/test/Atom.jl
+++ b/test/Atom.jl
@@ -1,7 +1,7 @@
 @testset "Atom Type" begin
     a = Atom("He")
 
-    @test mass(a) ≈ 4.002602 atol=1e-6
+    @test_approx_eq_eps mass(a) 4.002602 1e-6
     @test charge(a) == 0
     @test name(a) == "He"
     @test atom_type(a) == "He"
@@ -18,7 +18,7 @@
     @test atom_type(a) == "Zn"
     @test fullname(a) == "Zinc"
 
-    @test vdw_radius(a) ≈ 2.1 atol=1e-1
-    @test covalent_radius(a) ≈ 1.31 atol=1e-2
+    @test_approx_eq_eps vdw_radius(a) 2.1 1e-1
+    @test_approx_eq_eps covalent_radius(a) 1.31 1e-2
     @test atomic_number(a) == 30
 end

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -41,4 +41,14 @@
     @test step(frame) == 0
     set_step!(frame, 42)
     @test step(frame) == 42
+
+    @test natoms(frame) == 4
+
+    position = Float64[0.2, 0.8, 0]
+    velocity = Float64[1, 2, 1]
+    add_atom!(frame, Atom("H"), position, velocity)
+    @test natoms(frame) == 5
+
+    remove_atom!(frame, 4)
+    @test natoms(frame) == 4
 end

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -7,7 +7,7 @@ facts("Frame type") do
     @fact size(frame) --> 4
 
     pos = positions(frame)
-    expected = Array(Float64, 3, 4)
+    expected = Array{Float64}(3, 4)
     for i=1:3, j=1:4
         pos[i, j] = i*j
         expected[i, j] = i*j

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -42,13 +42,13 @@
     set_step!(frame, 42)
     @test step(frame) == 42
 
-    @test natoms(frame) == 4
+    @test size(frame) == 4
 
     position = Float64[0.2, 0.8, 0]
     velocity = Float64[1, 2, 1]
     add_atom!(frame, Atom("H"), position, velocity)
-    @test natoms(frame) == 5
+    @test size(frame) == 5
 
     remove_atom!(frame, 4)
-    @test natoms(frame) == 4
+    @test size(frame) == 4
 end

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -1,10 +1,9 @@
-
-facts("Frame type") do
+@testset "Frame Type" begin
     frame = Frame()
-    @fact size(frame) --> 0
+    @test size(frame) == 0
 
     resize!(frame, 4)
-    @fact size(frame) --> 4
+    @test size(frame) == 4
 
     pos = positions(frame)
     expected = Array{Float64}(3, 4)
@@ -12,21 +11,21 @@ facts("Frame type") do
         pos[i, j] = i*j
         expected[i, j] = i*j
     end
-    @fact positions(frame) --> expected
+    @test positions(frame) == expected
 
-    @fact has_velocities(frame) --> false
+    @test has_velocities(frame) == false
     add_velocities!(frame)
-    @fact has_velocities(frame) --> true
+    @test has_velocities(frame) == true
 
     vel = velocities(frame)
     for i=1:3, j=1:4
         vel[i, j] = i*j
     end
-    @fact velocities(frame) --> expected
+    @test velocities(frame) == expected
 
     set_cell!(frame, UnitCell(3, 4, 5))
     cell = UnitCell(frame)
-    @fact lengths(cell) --> [3.0, 4.0, 5.0]
+    @test lengths(cell) == [3.0, 4.0, 5.0]
 
     top = Topology()
     push!(top, Atom("H"))
@@ -36,10 +35,10 @@ facts("Frame type") do
     set_topology!(frame, top)
     new_top = Topology(frame)
 
-    @fact name(Atom(new_top, 0)) --> "H"
-    @fact name(Atom(new_top, 2)) --> "Zn"
+    @test name(Atom(new_top, 0)) == "H"
+    @test name(Atom(new_top, 2)) == "Zn"
 
-    @fact step(frame) --> 0
+    @test step(frame) == 0
     set_step!(frame, 42)
-    @fact step(frame) --> 42
+    @test step(frame) == 42
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-FactCheck

--- a/test/Residue.jl
+++ b/test/Residue.jl
@@ -23,5 +23,5 @@
     @test_throws ChemfilesError Residue(top, 3)
     add_residue!(top, residue)
     res = Residue(top, 0)
-    @test natoms(res) == 3
+    @test size(res) == 3
 end

--- a/test/Residue.jl
+++ b/test/Residue.jl
@@ -18,11 +18,10 @@
 
     @test contains(residue, 56) == true
 
-    # TODO: Test chfl_from_topology
-    # top = Topology()
-    # push!(top, Atom("H"))
-    # push!(top, Atom("O"))
-    # push!(top, Atom("Zn"))
-    # push!(top, Atom("H"))
-    # residue = Residue(top, 3)
+    top = Topology()
+    @test count_residues(top) == 0
+    @test_throws ChemfilesError Residue(top, 3)
+    add_residue!(top, residue)
+    res = Residue(top, 0)
+    @test natoms(res) == 3
 end

--- a/test/Residue.jl
+++ b/test/Residue.jl
@@ -1,0 +1,28 @@
+@testset "Residue type" begin
+    residue = Residue("ALA", 4)
+    @test name(residue) == "ALA"
+    @test id(residue) == 4
+
+    residue = Residue("GUA")
+    @test name(residue) == "GUA"
+    @test id(residue) == typemax(UInt64)
+
+    @test size(residue) == 0
+    add_atom!(residue, 0);
+    add_atom!(residue, 56);
+    add_atom!(residue, 30);
+    @test size(residue) == 3
+
+    add_atom!(residue, 56)
+    size(residue) == 3
+
+    @test contains(residue, 56) == true
+
+    # TODO: Test chfl_from_topology
+    # top = Topology()
+    # push!(top, Atom("H"))
+    # push!(top, Atom("O"))
+    # push!(top, Atom("Zn"))
+    # push!(top, Atom("H"))
+    # residue = Residue(top, 3)
+end

--- a/test/Selection.jl
+++ b/test/Selection.jl
@@ -49,4 +49,6 @@ end
     matches = evaluate(selection, frame)
     @test size(matches, 1) == 1
     @test ((0, 1, 2, 3) in matches) == true
+
+    @test selection_string(selection) == "dihedrals: all"
 end

--- a/test/Selection.jl
+++ b/test/Selection.jl
@@ -16,38 +16,37 @@ function testing_frame()
     return frame
 end
 
-
-facts("Selection type") do
+@testset "Selection type" begin
     frame = testing_frame()
     selection = Selection("name O")
-    @fact size(selection) --> 1
+    @test size(selection) == 1
 
     matches = evaluate(selection, frame)
-    @fact size(matches, 1) --> 2
-    @fact matches[1] --> 1
-    @fact matches[2] --> 2
+    @test size(matches, 1) == 2
+    @test matches[1] == 1
+    @test matches[2] == 2
 
     selection = Selection("bonds: all")
-    @fact size(selection) --> 2
+    @test size(selection) == 2
 
     matches = evaluate(selection, frame)
-    @fact size(matches, 1) --> 3
-    @fact (0, 1) in matches --> true
-    @fact (1, 2) in matches --> true
-    @fact (2, 3) in matches --> true
+    @test size(matches, 1) == 3
+    @test ((0, 1) in matches) == true
+    @test ((1, 2) in matches) == true
+    @test ((2, 3) in matches) == true
 
     selection = Selection("angles: all")
-    @fact size(selection) --> 3
+    @test size(selection) == 3
 
     matches = evaluate(selection, frame)
-    @fact size(matches, 1) --> 2
-    @fact (0, 1, 2) in matches --> true
-    @fact (1, 2, 3) in matches --> true
+    @test size(matches, 1) == 2
+    @test ((0, 1, 2) in matches) == true
+    @test ((1, 2, 3) in matches) == true
 
     selection = Selection("dihedrals: all")
-    @fact size(selection) --> 4
+    @test size(selection) == 4
 
     matches = evaluate(selection, frame)
-    @fact size(matches, 1) --> 1
-    @fact (0, 1, 2, 3) in matches --> true
+    @test size(matches, 1) == 1
+    @test ((0, 1, 2, 3) in matches) == true
 end

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -57,10 +57,10 @@
             add_residue!(topo, res)
         end
 
-        @test residues(topo) == 3
+        @test count_residues(topo) == 3
 
-        first = Residue(topo, 2, atom=true)
-        second = Residue(topo, 0, atom=true)
+        first = residue_for_atom(topo, 2)
+        second = residue_for_atom(topo, 0)
 
         @test first != nothing
         @test second != nothing
@@ -68,7 +68,7 @@
 
         @test are_linked(topo, first, second) == false
 
-        @show add_bond!(topo, 6, 9)
+        add_bond!(topo, 6, 9)
         @test are_linked(topo, first, second) == true
     end
 end

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -1,47 +1,46 @@
-
-facts("Topology type") do
+@testset "Topology type" begin
     top = Topology()
 
-    @fact natoms(top) --> 0
-    @fact size(top) --> 0
+    @test natoms(top) == 0
+    @test size(top) == 0
 
     # Creating some H2O2
     push!(top, Atom("H"))
     push!(top, Atom("O"))
     push!(top, Atom("O"))
     push!(top, Atom("H"))
-    @fact natoms(top) --> 4
+    @test natoms(top) == 4
 
-    @fact nbonds(top) --> 0
-    @fact nangles(top) --> 0
-    @fact ndihedrals(top) --> 0
+    @test nbonds(top) == 0
+    @test nangles(top) == 0
+    @test ndihedrals(top) == 0
 
     add_bond!(top, 0, 1)
     add_bond!(top, 1, 2)
     add_bond!(top, 2, 3)
 
-    @fact nbonds(top) --> 3
-    @fact nangles(top) --> 2
-    @fact ndihedrals(top) --> 1
+    @test nbonds(top) == 3
+    @test nangles(top) == 2
+    @test ndihedrals(top) == 1
 
-    @fact isbond(top, 0, 1) --> true
-    @fact isbond(top, 0, 3) --> false
-    @fact isangle(top, 0, 1, 2) --> true
-    @fact isangle(top, 0, 1, 3) --> false
-    @fact isdihedral(top, 0, 1, 2, 3) --> true
-    @fact isdihedral(top, 0, 1, 3, 2) --> false
+    @test isbond(top, 0, 1) == true
+    @test isbond(top, 0, 3) == false
+    @test isangle(top, 0, 1, 2) == true
+    @test isangle(top, 0, 1, 3) == false
+    @test isdihedral(top, 0, 1, 2, 3) == true
+    @test isdihedral(top, 0, 1, 3, 2) == false
 
     top_bonds = reshape(UInt64[0, 1,   1, 2,   2, 3], (2, 3))
 
-    @fact bonds(top) --> top_bonds
-    @fact angles(top) --> reshape(UInt64[0, 1, 2,   1, 2, 3,], (3, 2))
-    @fact dihedrals(top) --> reshape(UInt64[0, 1, 2, 3], (4,1))
+    @test bonds(top) == top_bonds
+    @test angles(top) == reshape(UInt64[0, 1, 2,   1, 2, 3,], (3, 2))
+    @test dihedrals(top) == reshape(UInt64[0, 1, 2, 3], (4,1))
 
     remove_bond!(top, 2, 3)
-    @fact nbonds(top) --> 2
-    @fact nangles(top) --> 1
-    @fact ndihedrals(top) --> 0
+    @test nbonds(top) == 2
+    @test nangles(top) == 1
+    @test ndihedrals(top) == 0
 
     remove!(top, 3)
-    @fact natoms(top) --> 3
+    @test natoms(top) == 3
 end

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -43,4 +43,29 @@
 
     remove!(top, 3)
     @test natoms(top) == 3
+
+    @testset "Residues" begin
+        topo = Topology()
+        [push!(topo, Atom("X")) for i=0:10]
+
+        for atoms in [[2,3,6], [0,1,9], [4,5,8]]
+            res = Residue("X")
+            [add_atom!(res, i) for i in atoms]
+            add_residue!(topo, res)
+        end
+
+        @test residues(topo) == 3
+
+        first = Residue(topo, 2, atom=true)
+        second = Residue(topo, 0, atom=true)
+
+        @test first != nothing
+        @test second != nothing
+        @test_throws ChemfilesError Residue(topo, 4)
+
+        @test are_linked(topo, first, second) == false
+
+        @show add_bond!(topo, 6, 9)
+        @test are_linked(topo, first, second) == true
+    end
 end

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -44,6 +44,9 @@
     remove!(top, 3)
     @test natoms(top) == 3
 
+    resize!(top, 42)
+    @test size(top) == 42
+
     @testset "Residues" begin
         topo = Topology()
         [push!(topo, Atom("X")) for i=0:10]

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -1,7 +1,7 @@
 @testset "Topology type" begin
     top = Topology()
 
-    @test natoms(top) == 0
+    @test size(top) == 0
     @test size(top) == 0
 
     # Creating some H2O2
@@ -9,7 +9,7 @@
     push!(top, Atom("O"))
     push!(top, Atom("O"))
     push!(top, Atom("H"))
-    @test natoms(top) == 4
+    @test size(top) == 4
 
     @test nbonds(top) == 0
     @test nangles(top) == 0
@@ -42,7 +42,7 @@
     @test ndihedrals(top) == 0
 
     remove!(top, 3)
-    @test natoms(top) == 3
+    @test size(top) == 3
 
     resize!(top, 42)
     @test size(top) == 42

--- a/test/Trajectory.jl
+++ b/test/Trajectory.jl
@@ -14,13 +14,13 @@ const DATAPATH = joinpath(dirname(@__FILE__), "data")
 
         frame = read(file)
 
-        @test natoms(frame) == 297
+        @test size(frame) == 297
         pos = positions(frame)
         @test pos[:, 1] == Float64[0.417219, 8.303366, 11.737172]
         @test pos[:, 125] == Float64[5.099554, -0.045104, 14.153846]
 
         topology = Topology(frame)
-        @test natoms(topology) == 297
+        @test size(topology) == 297
         @test name(Atom(topology, 0)) == "O"
         @test name(Atom(frame, 1)) == "H"
 
@@ -34,7 +34,7 @@ const DATAPATH = joinpath(dirname(@__FILE__), "data")
         @test pos[:, 125] == Float64[5.13242, 0.079862, 14.194161]
 
         topology = Topology(frame)
-        @test natoms(topology) == 297
+        @test size(topology) == 297
         @test nbonds(topology) == 0
 
         guess_bonds!(frame)

--- a/test/Trajectory.jl
+++ b/test/Trajectory.jl
@@ -1,46 +1,46 @@
 
 const DATAPATH = joinpath(dirname(@__FILE__), "data")
 
-facts("Trajectory type") do
-    context("Errors handling") do
-        @fact_throws Trajectory(joinpath(DATAPATH, "not-here.xyz"))
-        @fact_throws Trajectory(joinpath(DATAPATH, "empty.unknown"))
+@testset "Trajectory type" begin
+    @testset "Errors handling" begin
+        @test_throws ChemfilesError Trajectory(joinpath(DATAPATH, "not-here.xyz"))
+        @test_throws ChemfilesError Trajectory(joinpath(DATAPATH, "empty.unknown"))
     end
 
-    context("Read frames") do
+    @testset "Read frames" begin
         file = Trajectory(joinpath(DATAPATH, "water.xyz"))
 
-        @fact nsteps(file) --> 100
+        @test nsteps(file) == 100
 
         frame = read(file)
 
-        @fact natoms(frame) --> 297
+        @test natoms(frame) == 297
         pos = positions(frame)
-        @fact pos[:, 1] --> Float64[0.417219, 8.303366, 11.737172]
-        @fact pos[:, 125] --> Float64[5.099554, -0.045104, 14.153846]
+        @test pos[:, 1] == Float64[0.417219, 8.303366, 11.737172]
+        @test pos[:, 125] == Float64[5.099554, -0.045104, 14.153846]
 
         topology = Topology(frame)
-        @fact natoms(topology) --> 297
-        @fact name(Atom(topology, 0)) --> "O"
-        @fact name(Atom(frame, 1)) --> "H"
+        @test natoms(topology) == 297
+        @test name(Atom(topology, 0)) == "O"
+        @test name(Atom(frame, 1)) == "H"
 
         set_cell!(file, UnitCell(30, 30, 30))
         frame = read_step(file, 41)
 
-        @fact lengths(UnitCell(frame)) --> [30.0, 30.0, 30.0]
+        @test lengths(UnitCell(frame)) == [30.0, 30.0, 30.0]
 
         pos = positions(frame)
-        @fact pos[:, 1] --> Float64[0.761277, 8.106125, 10.622949]
-        @fact pos[:, 125] --> Float64[5.13242, 0.079862, 14.194161]
+        @test pos[:, 1] == Float64[0.761277, 8.106125, 10.622949]
+        @test pos[:, 125] == Float64[5.13242, 0.079862, 14.194161]
 
         topology = Topology(frame)
-        @fact natoms(topology) --> 297
-        @fact nbonds(topology) --> 0
+        @test natoms(topology) == 297
+        @test nbonds(topology) == 0
 
         guess_bonds!(frame)
         topology = Topology(frame)
-        @fact nbonds(topology) --> 181
-        @fact nangles(topology) --> 87
+        @test nbonds(topology) == 181
+        @test nangles(topology) == 87
 
         topology = Topology()
         a = Atom("Cs")
@@ -50,14 +50,14 @@ facts("Trajectory type") do
 
         set_topology!(file, topology)
         frame = read_step(file, 10)
-        @fact name(Atom(frame, 10)) --> "Cs"
+        @test name(Atom(frame, 10)) == "Cs"
 
         set_topology!(file, joinpath(DATAPATH, "topology.xyz"))
         frame = read(file)
-        @fact name(Atom(frame, 100)) --> "Rd"
+        @test name(Atom(frame, 100)) == "Rd"
     end
 
-    context("Write frames") do
+    @testset "Write frames" begin
         expected_content = """4
                               Written by the chemfiles library
                               X 1 2 3
@@ -103,10 +103,10 @@ facts("Trajectory type") do
 
         write(file, frame)
         close(file)
-        @fact isopen(file) --> false
+        @test isopen(file) == false
 
         open("test-tmp.xyz") do fd
-            @fact readstring(fd) --> expected_content
+            @test readstring(fd) == expected_content
         end
 
         rm("test-tmp.xyz")

--- a/test/UnitCell.jl
+++ b/test/UnitCell.jl
@@ -20,7 +20,7 @@
     expected = reshape(Float64[10, 0, 0,
                                0, 20, 0,
                                0, 0, 30], (3, 3))
-    @test cell_matrix(cell) ≈ expected atol=1e-10
+    @test_approx_eq_eps cell_matrix(cell) expected 1e-10
 
     @test shape(cell) == Chemfiles.ORTHORHOMBIC
 

--- a/test/UnitCell.jl
+++ b/test/UnitCell.jl
@@ -20,7 +20,7 @@
     expected = reshape(Float64[10, 0, 0,
                                0, 20, 0,
                                0, 0, 30], (3, 3))
-    @test cell_matrix(cell) ≈ expected
+    @test cell_matrix(cell) ≈ expected atol=1e-10
 
     @test shape(cell) == Chemfiles.ORTHORHOMBIC
 

--- a/test/UnitCell.jl
+++ b/test/UnitCell.jl
@@ -1,33 +1,32 @@
-
-facts("UnitCell type") do
+@testset "UnitCell type" begin
     cell = UnitCell(5, 3, 1, 110, 120, 80)
 
-    @fact lengths(cell) --> [5.0, 3.0, 1.0]
-    @fact angles(cell) --> [110.0, 120.0, 80.0]
+    @test lengths(cell) == [5.0, 3.0, 1.0]
+    @test angles(cell) == [110.0, 120.0, 80.0]
 
     cell = UnitCell(2, 3, 4)
 
-    @fact lengths(cell) --> [2.0, 3.0, 4.0]
-    @fact angles(cell) --> [90.0, 90.0, 90.0]
+    @test lengths(cell) == [2.0, 3.0, 4.0]
+    @test angles(cell) == [90.0, 90.0, 90.0]
 
-    @fact volume(cell) --> 2.0 * 3.0 * 4.0
+    @test volume(cell) == 2.0 * 3.0 * 4.0
 
     set_lengths!(cell, 10, 20, 30)
-    @fact lengths(cell) --> [10.0, 20.0, 30.0]
+    @test lengths(cell) == [10.0, 20.0, 30.0]
 
     # Can not set angles for ORTHORHOMBIC cell
-    @fact_throws set_angles!(cell, 80, 89, 100)
+    @test_throws ChemfilesError set_angles!(cell, 80, 89, 100)
 
     expected = reshape(Float64[10, 0, 0,
                                0, 20, 0,
                                0, 0, 30], (3, 3))
-    @fact cell_matrix(cell) --> roughly(expected, 1e-10)
+    @test cell_matrix(cell) ≈ expected
 
-    @fact shape(cell) --> Chemfiles.ORTHORHOMBIC
+    @test shape(cell) == Chemfiles.ORTHORHOMBIC
 
     set_shape!(cell, Chemfiles.TRICLINIC)
-    @fact shape(cell) --> Chemfiles.TRICLINIC
+    @test shape(cell) == Chemfiles.TRICLINIC
 
     set_angles!(cell, 80, 89, 100)
-    @fact angles(cell) --> [80.0, 89.0, 100.0]
+    @test angles(cell) == [80.0, 89.0, 100.0]
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,5 +1,6 @@
 function warning_callback(message::String)
-    warn("[TEST][chemfiles] ", message)
+    global TEST_CALLBACK = true
+    nothing
 end
 
 @testset "Error Functions" begin
@@ -10,7 +11,10 @@ end
 
     @test Chemfiles.last_error() == ""
 
-    @test_warn "[chemfiles]" @test_throws ChemfilesError Residue(Topology(), 3)
+    @test_throws ChemfilesError Residue(Topology(), 3)
+    @test_throws UndefVarError TEST_CALLBACK == false
+
     set_warning_callback(warning_callback)
-    @test_warn "[TEST][chemfiles]" @test_throws ChemfilesError Residue(Topology(), 3)
+    @test_throws ChemfilesError Residue(Topology(), 3)
+    @test TEST_CALLBACK == true
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,5 +1,5 @@
-function warning_callback(message::Ptr{UInt8})
-    warn("Warn Test")
+function warning_callback(message::String)
+    warn("[TEST][chemfiles] ", message)
 end
 
 @testset "Error Functions" begin
@@ -10,7 +10,7 @@ end
 
     @test Chemfiles.last_error() == ""
 
-    # TODO: Tests warning_callback
-    # set_warning_callback(warning_callback)
-    # @test_warn "Warn Test" Residue(Topology(), 3)
+    @test_warn "[chemfiles]" @test_throws ChemfilesError Residue(Topology(), 3)
+    set_warning_callback(warning_callback)
+    @test_warn "[TEST][chemfiles]" @test_throws ChemfilesError Residue(Topology(), 3)
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,9 +1,8 @@
-
-facts("Error functions") do
+@testset "Error Functions" begin
     err = ChemfilesError("oops")
     iobuf = IOBuffer(19 + length(err.message))
     show(iobuf, err)
-    @fact String(iobuf.data) --> "\"Chemfiles error: oops\""
+    @test String(iobuf.data) == "\"Chemfiles error: oops\""
 
-    @fact Chemfiles.last_error() --> ""
+    @test Chemfiles.last_error() == ""
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,3 +1,7 @@
+function warning_callback(message::Ptr{UInt8})
+    warn("Warn Test")
+end
+
 @testset "Error Functions" begin
     err = ChemfilesError("oops")
     iobuf = IOBuffer(19 + length(err.message))
@@ -5,4 +9,8 @@
     @test String(iobuf.data) == "\"Chemfiles error: oops\""
 
     @test Chemfiles.last_error() == ""
+
+    # TODO: Tests warning_callback
+    # set_warning_callback(warning_callback)
+    # @test_warn "Warn Test" Residue(Topology(), 3)
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,7 +1,7 @@
 
 facts("Error functions") do
     err = ChemfilesError("oops")
-    iobuf = IOBuffer()
+    iobuf = IOBuffer(19 + length(err.message))
     show(iobuf, err)
     @fact String(iobuf.data) --> "\"Chemfiles error: oops\""
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Chemfiles
-using FactCheck
 using Base.Test
 
 TESTS = [
@@ -8,14 +7,13 @@ TESTS = [
 ]
 
 function main()
-    facts("Generics") do
-        @fact Chemfiles.version() --> "0.7.4"
+    @testset "Generics" begin
+        @test Chemfiles.version() == "0.7.4"
     end
     root = dirname(@__FILE__)
     for test in TESTS
         include(test)
     end
-    FactCheck.exitstatus()
 end
 
 main()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 TESTS = [
     "errors.jl", "Atom.jl", "Topology.jl", "UnitCell.jl", "Frame.jl",
-    "Trajectory.jl", "Selection.jl"
+    "Trajectory.jl", "Selection.jl", "Residue.jl"
 ]
 
 function main()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Chemfiles
 using FactCheck
+using Base.Test
 
 TESTS = [
     "errors.jl", "Atom.jl", "Topology.jl", "UnitCell.jl", "Frame.jl",


### PR DESCRIPTION
- [x] fix deprecation warning from Julia 0.5 to Julia 0.6
- [x] Remove FactCheck.jl and Rewrite tests using Base.Test
- [x] Add Residue type and associated functions (code + test)
- [x] Wrap chfl_set_warning_callback (code + test)
- [x] Provide default warning callback using julia warnings
- [x] Add missing functions:
   - [x] chfl_frame_add_atom (code + test)
   - [x] chfl_frame_remove (code + test)
   - [x] chfl_topology_resize (code + test)
   - [x] chfl_topology_add_residue (code + test)
   - [x] chfl_topology_residues_count(code + test)
   - [x] chfl_topology_residues_linked (code + test)
   - [x] chfl_selection_string (code + test)
- [x] update documentation by comparing with chemfiles.h and other headers in include/chemfiles/capi