### PR TITLE
loosen dependency requirement versions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.5
-BinDeps 0.4
-Compat 0.12
+BinDeps 0.3.19
 Conda 0.5


### PR DESCRIPTION
Compat doesn't appear to be used here at the moment
BinDeps 0.3.19 appears to work okay on Julia 0.5 (tested locally on Linux via Pkg.pin) - earlier versions had an issue with missing jl_uv_dlopen https://github.com/JuliaLang/BinDeps.jl/commit/a5339997b5882ad9265b9c8fbd138fae2c2c402e