### PR TITLE
Update to Chemfiles 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 BinDeps 0.3.19
 Conda 0.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 BinDeps 0.3.19
-Conda 0.5
+Conda 0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.6
 BinDeps 0.3.19
-Conda 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
               "C:\projects\julia-installer.exe"
         )
   - C:\projects\julia-installer.exe /S /D=C:\projects\julia
+  - C:\projects\julia\bin\julia -e "Pkg.add(\"Conda\"); using Conda; Conda.list(); Conda.update()"
 
 build_script:
   - IF EXIST .git\shallow (git fetch --unshallow)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,10 @@ environment:
   matrix:
       - JULIA_VERSION: "v0.6"
         ARCH: x86
-        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6.0-win32.exe"
+        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6.2-win32.exe"
       - JULIA_VERSION: "v0.6"
         ARCH: x64
-        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6.0-win64.exe"
+        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6.2-win64.exe"
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,5 @@
 environment:
   matrix:
-      - JULIA_VERSION: "v0.5"
-        ARCH: x86
-        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5.2-win32.exe"
-      - JULIA_VERSION: "v0.5"
-        ARCH: x64
-        JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5.2-win64.exe"
       - JULIA_VERSION: "v0.6"
         ARCH: x86
         JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6.0-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ install:
               "C:\projects\julia-installer.exe"
         )
   - C:\projects\julia-installer.exe /S /D=C:\projects\julia
-  - C:\projects\julia\bin\julia -e "Pkg.add(\"Conda\"); using Conda; Conda.list(); Conda.update()"
 
 build_script:
   - IF EXIST .git\shallow (git fetch --unshallow)

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,1 +1,3 @@
 deps.jl
+*.tar.bz2
+usr/

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ function unpack(file, directory)
         run(`tar xjf $file --directory=$directory`)
     elseif is_windows()
         exe7z = joinpath(_HOME, "7z.exe")
-        pipeline(`$exe7z x $file -y -so`, `$exe7z x -si -y -ttar -o$directory`)
+        run(pipeline(`$exe7z x $file -y -so`, `$exe7z x -si -y -ttar -o$directory`))
     end
 end
 
@@ -59,7 +59,7 @@ unpack(LOCAL_ARCHIVE, joinpath(@__DIR__, "usr"))
 
 LIBPATH = joinpath(@__DIR__, "usr", unpacked_file)
 
-DEPS_JL = """
+write(joinpath(@__DIR__, "deps.jl"), """
 # This is an auto-generated file; do not edit
 
 # Macro to load a library
@@ -69,7 +69,5 @@ macro checked_lib(libname, path)
 end
 
 # Load dependencies
-@checked_lib libchemfiles "$LIBPATH"
-"""
-
-write(joinpath(@__DIR__, "deps.jl"), DEPS_JL)
+@checked_lib libchemfiles "$(escape_string(LIBPATH))"
+""")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 @BinDeps.setup
 
 libchemfiles = library_dependency("libchemfiles", aliases = ["chemfiles"])
-version = "0.7.4"
+version = "0.8.0"
 
 if Pkg.installed("Conda") === nothing
     error("Conda package not installed, please run Pkg.add(\"Conda\")")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,16 +1,75 @@
-using BinDeps
-@BinDeps.setup
-
-libchemfiles = library_dependency("libchemfiles", aliases = ["chemfiles"])
 version = "0.8.0"
+linux_build_id = "1"
+macos_build_id = "1"
+windows_build_id = "vc14_1"
 
-if Pkg.installed("Conda") === nothing
-    error("Conda package not installed, please run Pkg.add(\"Conda\")")
+function is_64_bits()
+    return Int == Int64
 end
-using Conda
-if !("conda-forge" in Conda.channels())
-    Conda.add_channel("conda-forge")
-end
-provides(Conda.Manager, "chemfiles-lib==$(version)", libchemfiles)
 
-@BinDeps.install Dict(:libchemfiles => :libchemfiles)
+if VERSION >= v"0.7.0-DEV.3073"
+    const _HOME = Sys.BINDIR
+else
+    const _HOME = JULIA_HOME
+end
+
+function unpack(file, directory)
+    if is_unix()
+        run(`mkdir -p $directory`)
+        run(`tar xjf $file --directory=$directory`)
+    elseif is_windows()
+        exe7z = joinpath(_HOME, "7z.exe")
+        pipeline(`$exe7z x $file -y -so`, `$exe7z x -si -y -ttar -o$directory`)
+    end
+end
+
+
+if is_windows()
+    build_id = windows_build_id
+    unpacked_file = joinpath("Library", "bin", "chemfiles.dll")
+    if is_64_bits()
+        platform = "win-64"
+    else
+        assert(Int == Int32)
+        platform = "win-32"
+    end
+elseif is_linux()
+    build_id = linux_build_id
+    unpacked_file = joinpath("lib", "libchemfiles.so.$version")
+    if !is_64_bits()
+        error("There is no prebuilt chemfiles library for 32bit Linux")
+    end
+    platform = "linux-64"
+elseif is_apple()
+    build_id = macos_build_id
+    unpacked_file = joinpath("lib", "libchemfiles.$version.dylib")
+    if !is_64_bits()
+        error("There is no prebuilt chemfiles library for 32bit macOS")
+    end
+    platform = "osx-64"
+else
+    error("Could not find a prebuilt chemfiles library for the current platform")
+end
+
+URL = "https://anaconda.org/conda-forge/chemfiles-lib/$version/download/$platform/chemfiles-lib-$version-$build_id.tar.bz2"
+LOCAL_ARCHIVE = joinpath(@__DIR__, basename(URL))
+
+download(URL, LOCAL_ARCHIVE)
+unpack(LOCAL_ARCHIVE, joinpath(@__DIR__, "usr"))
+
+LIBPATH = joinpath(@__DIR__, "usr", unpacked_file)
+
+DEPS_JL = """
+# This is an auto-generated file; do not edit
+
+# Macro to load a library
+macro checked_lib(libname, path)
+    Base.Libdl.dlopen_e(path) == C_NULL && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
+    quote const \$(esc(libname)) = \$path end
+end
+
+# Load dependencies
+@checked_lib libchemfiles "$LIBPATH"
+"""
+
+write(joinpath(@__DIR__, "deps.jl"), DEPS_JL)

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export mass, set_mass!, charge, set_charge!, name, set_name!, fullname, vdw_radius,
-covalent_radius, atomic_number, atom_type, set_atom_type!, AtomType
+covalent_radius, atomic_number, atom_type, set_atom_type!, set_property!, get_property, AtomType
 
 """
 Create an atom with the given ``name`` and set the atom ``type`` to be the same
@@ -172,11 +172,28 @@ Get the atomic number of an ``atom`` from the atom type.
 If the atomic number can not be found, returns -1.
 """
 function atomic_number(atom::Atom)
-    number = Ref{Int64}(0)
+    number = Ref{UInt64}(0)
     check(
         lib.chfl_atom_atomic_number(atom.handle, number)
     )
     return number[]
+end
+
+"""
+Set a named property for the given atom.
+"""
+function set_property!(atom::Atom, name::String, property::Property)
+    check(
+        lib.chfl_atom_set_property(atom.handle, pointer(name), property.handle)
+    )
+    return nothing
+end
+
+"""
+Get a named property for the given atom.
+"""
+function get_property(atom::Atom, name::String)
+    Property(lib.chfl_atom_get_property(atom.handle, pointer(name)))
 end
 
 """

--- a/src/Atom.jl
+++ b/src/Atom.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export mass, set_mass!, charge, set_charge!, name, set_name!, fullname, vdw_radius,
-covalent_radius, atomic_number, atom_type, set_atom_type!, set_property!, get_property, AtomType
+covalent_radius, atomic_number, atom_type, set_atom_type!, set_property!, property, AtomType
 
 """
 Create an atom with the given ``name`` and set the atom ``type`` to be the same
@@ -169,7 +169,7 @@ end
 """
 Get the atomic number of an ``atom`` from the atom type.
 
-If the atomic number can not be found, returns -1.
+If the atomic number can not be found, returns 0.
 """
 function atomic_number(atom::Atom)
     number = Ref{UInt64}(0)
@@ -182,9 +182,12 @@ end
 """
 Set a named property for the given atom.
 """
-function set_property!(atom::Atom, name::String, property::Property)
+function set_property!(atom::Atom, name::String, property)
+
+    prop = Property(property)
+
     check(
-        lib.chfl_atom_set_property(atom.handle, pointer(name), property.handle)
+        lib.chfl_atom_set_property(atom.handle, pointer(name), prop.handle)
     )
     return nothing
 end
@@ -192,8 +195,8 @@ end
 """
 Get a named property for the given atom.
 """
-function get_property(atom::Atom, name::String)
-    Property(lib.chfl_atom_get_property(atom.handle, pointer(name)))
+function property(atom::Atom, name::String)
+    get(Property(lib.chfl_atom_get_property(atom.handle, pointer(name))))
 end
 
 """

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -19,7 +19,7 @@ module Chemfiles
 
     include("errors.jl")
 
-    export Trajectory, Topology, Atom, UnitCell, Frame, Selection, Residue, Property
+    export Trajectory, Topology, Atom, UnitCell, Frame, Selection, Residue
 
     function version()
         unsafe_string(lib.chfl_version())
@@ -39,7 +39,7 @@ module Chemfiles
     or write one or many ``Frame`` to this file. The file format can be
     automatically determined from the extention, or manually specified.
     """
-    type Trajectory
+    mutable struct Trajectory
         handle :: Ptr{lib.CHFL_TRAJECTORY}
         function Trajectory(ptr::Ptr{lib.CHFL_TRAJECTORY})
             check(ptr)
@@ -55,7 +55,7 @@ module Chemfiles
     is a list of ``Atom`` in the system, together with the list of bonds between
     the atoms.
     """
-    type Topology
+    mutable struct Topology
         handle :: Ptr{lib.CHFL_TOPOLOGY}
         function Topology(ptr::Ptr{lib.CHFL_TOPOLOGY})
             check(ptr)
@@ -77,7 +77,7 @@ module Chemfiles
     The atom name is usually an unique identifier ("H1", "C_a") while the atom
     type will be shared between all particles of the same type: "H", "Ow", "CH3".
     """
-    type Atom
+    mutable struct Atom
         handle :: Ptr{lib.CHFL_ATOM}
         function Atom(ptr::Ptr{lib.CHFL_ATOM})
             check(ptr)
@@ -92,7 +92,7 @@ module Chemfiles
     three base vectors of lengthes ``a``, ``b`` and ``c``; and the angles
     between these vectors are ``alpha``, ``beta`` and ``gamma``.
     """
-    type UnitCell
+    mutable struct UnitCell
         handle :: Ptr{lib.CHFL_CELL}
         function UnitCell(ptr::Ptr{lib.CHFL_CELL})
             check(ptr)
@@ -112,7 +112,7 @@ module Chemfiles
     - The ``Topology`` of the system;
     - The ``UnitCell`` of the system.
     """
-    type Frame
+    mutable struct Frame
         handle :: Ptr{lib.CHFL_FRAME}
         function Frame(ptr::Ptr{lib.CHFL_FRAME})
             check(ptr)
@@ -128,7 +128,7 @@ module Chemfiles
     <http://chemfiles.readthedocs.io/en/latest/selections.html>`_ for more
     information about the selection language.
     """
-    type Selection
+    mutable struct Selection
         handle :: Ptr{lib.CHFL_SELECTION}
         function Selection(ptr::Ptr{lib.CHFL_SELECTION})
             check(ptr)
@@ -143,7 +143,7 @@ module Chemfiles
     can be small molecules, amino-acids in a protein, monomers in polymers,
     *etc.*
     """
-    type Residue
+    mutable struct Residue
         handle :: Ptr{lib.CHFL_RESIDUE}
         function Residue(ptr::Ptr{lib.CHFL_RESIDUE})
             check(ptr)
@@ -157,7 +157,7 @@ module Chemfiles
     A ``Property`` is a generic container for various forms of metadata
     stored for other structures.
     """
-    type Property
+    mutable struct Property
         handle :: Ptr{lib.CHFL_PROPERTY}
         function Property(ptr::Ptr{lib.CHFL_PROPERTY})
             check(ptr)

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -19,7 +19,7 @@ module Chemfiles
 
     include("errors.jl")
 
-    export Trajectory, Topology, Atom, UnitCell, Frame, Selection, Residue
+    export Trajectory, Topology, Atom, UnitCell, Frame, Selection, Residue, Property
 
     function version()
         unsafe_string(lib.chfl_version())
@@ -153,6 +153,20 @@ module Chemfiles
         end
     end
 
+    """
+    A ``Property`` is a generic container for various forms of metadata
+    stored for other structures.
+    """
+    type Property
+        handle :: Ptr{lib.CHFL_PROPERTY}
+        function Property(ptr::Ptr{lib.CHFL_PROPERTY})
+            check(ptr)
+            this = new(ptr)
+            finalizer(this, free)
+            return this
+        end
+    end
+
     include("Atom.jl")
     include("Frame.jl")
     include("Topology.jl")
@@ -160,4 +174,5 @@ module Chemfiles
     include("UnitCell.jl")
     include("Selection.jl")
     include("Residue.jl")
+    include("Property.jl")
 end

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -125,7 +125,7 @@ module Chemfiles
     """
     A ``Selection`` allow to select a group of atoms. Examples of selections are
     "name H" and "(x < 45 and name O) or name C". See the `full documentation
-    <http://chemfiles.readthedocs.io/en/latest/selections.html>`_ for more
+    <http://chemfiles.org/chemfiles/latest/selections.html>`_ for more
     information about the selection language.
     """
     mutable struct Selection

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export positions, velocities, add_atom!, remove_atom!, add_velocities!, has_velocities, set_cell!,
-set_topology!, set_step!, guess_bonds!, distance, bend, dihedral, out_of_plane, add_bond!, remove_bond!, add_residue!
+set_topology!, set_step!, guess_bonds!, distance, angle, dihedral, out_of_plane, add_bond!, remove_bond!, add_residue!
 
 """
 Create a new empty ``Frame``.
@@ -164,7 +164,7 @@ end
 """
 Calculate the angle made by three atoms.
 """
-function bend(frame::Frame, i::Integer, j::Integer, k::Integer)
+function Base.angle(frame::Frame, i::Integer, j::Integer, k::Integer)
     result = Ref{Float64}(0)
     check(
         lib.chfl_frame_angle(frame.handle, UInt64(i), UInt64(j), UInt64(k), result)

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 export positions, velocities, add_atom!, remove_atom!, add_velocities!, has_velocities, set_cell!,
-set_topology!, set_step!, guess_bonds!, distance, angle, dihedral, out_of_plane, add_bond!, remove_bond!, add_residue!
+set_topology!, set_step!, guess_bonds!, distance, dihedral, out_of_plane, add_bond!, remove_bond!, add_residue!
 
 """
 Create a new empty ``Frame``.
@@ -221,9 +221,12 @@ end
 """
 Set a named property for the given ``Frame``.
 """
-function set_property!(frame::Frame, name::String, property::Property)
+function set_property!(frame::Frame, name::String, property)
+
+    prop = Property(property)
+
     check(
-        lib.chfl_frame_set_property(frame.handle, pointer(name), property.handle)
+        lib.chfl_frame_set_property(frame.handle, pointer(name), prop.handle)
     )
     return nothing
 end
@@ -231,8 +234,8 @@ end
 """
 Get a named property for the given atom.
 """
-function get_property(frame::Frame, name::String)
-    Property(lib.chfl_frame_get_property(frame.handle, pointer(name)))
+function property(frame::Frame, name::String)
+    get(Property(lib.chfl_frame_get_property(frame.handle, pointer(name))))
 end
 
 """

--- a/src/Property.jl
+++ b/src/Property.jl
@@ -1,0 +1,123 @@
+# Copyright (c) Guillaume Fraux 2015
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+export Property, kind, free, get_bool, get_double, get_string, get_vector3d, PropertyKind
+
+"""
+The possible shape for an unit cell are:
+
+- ``Chemfiles.ORTHORHOMBIC`` for unit cell with the three angles are 90°
+- ``Chemfiles.TRICLINIC`` for unit cell where the three angles may not be 90°
+- ``Chemfiles.INFINITE`` for unit cells without boundaries
+"""
+type PropertyKind
+    value::lib.chfl_property_kind
+
+    function PropertyKind(value)
+        value = lib.chfl_property_kind(value)
+        if value in [lib.CHFL_PROPERTY_BOOL, lib.CHFL_PROPERTY_DOUBLE, lib.CHFL_PROPERTY_STRING, lib.CHFL_PROPERTY_VECTOR3D]
+            return new(value)
+        else
+            throw(ChemfilesError("Invalid value for conversion to PropertyType: $value"))
+        end
+    end
+end
+
+const PROPERTY_BOOL = PropertyKind(lib.CHFL_PROPERTY_BOOL)
+const PROPERTY_DOUBLE = PropertyKind(lib.CHFL_PROPERTY_DOUBLE)
+const PROPERTY_STRING = PropertyKind(lib.CHFL_PROPERTY_STRING)
+const PROPERTY_VECTOR3D = PropertyKind(lib.CHFL_PROPERTY_VECTOR3D)
+
+"""
+Create a ``Bool`` ``Property``.
+"""
+function Property(value::Bool)
+    return Property(lib.chfl_property_bool(convert(UInt8,value)))
+end
+
+"""
+Create a ``Float64`` ``Property``.
+"""
+function Property(value::Float64)
+    return Property(lib.chfl_property_double(value))
+end
+
+"""
+Create a ``String`` ``Property``.
+"""
+function Property(value::String)
+    return Property(lib.chfl_property_string(pointer(value)))
+end
+
+"""
+Create a ``Vector`` ``Property``.
+"""
+function Property(value::Vector{Float64})
+    return Property(lib.chfl_property_vector3d(value))
+end
+
+"""
+Obtain the kind of property.
+"""
+function kind(property::Property)
+    result = Ref{lib.chfl_property_kind}(0)
+    check(
+        lib.chfl_property_get_kind(property.handle, result)
+    )
+    return PropertyKind(result[])
+end
+
+"""
+Obtain a bool property.
+"""
+function get_bool(property::Property)
+    result = Ref{UInt8}(0)
+    check(
+        lib.chfl_property_get_bool(property.handle, result)
+    )
+    return convert(Bool, result[])
+end
+
+"""
+Obtain a double property.
+"""
+function get_double(property::Property)
+    result = Ref{Cdouble}(0)
+    check(
+        lib.chfl_property_get_double(property.handle, result)
+    )
+    return result[]
+end
+
+"""
+Obtain a string property.
+"""
+function get_string(property::Property, buffersize::Integer = 100)
+    buffersize = UInt64(buffersize)
+    str = " " ^ buffersize
+    check(
+        lib.chfl_property_get_string(property.handle, pointer(str), buffersize)
+    )
+    return strip_null(str)
+end
+
+"""
+Obtain a Vector3d property.
+"""
+function get_vector3d(property::Property)
+    result = Float64[0, 0, 0]
+    check(
+        lib.chfl_property_get_vector3d(property.handle, result)
+    )
+    return result
+end
+
+"""
+Free a ``Property``.
+"""
+function free(property::Property)
+    lib.chfl_property_free(property.handle)
+end

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -8,7 +8,6 @@ export name, id, add_atom!, residue_for_atom
 
 """
 Create a new residue with the given ``name``
-``resid``.
 """
 function Residue(name::String)
     handle = lib.chfl_residue(pointer(name))
@@ -16,8 +15,7 @@ function Residue(name::String)
 end
 
 """
-Create a new residue with the given ``name`` and residue identifier
-``resid``.
+Create a new residue with the given ``name`` and residue identifier ``resid``.
 """
 function Residue(name::String, resid::Integer)
     handle = lib.chfl_residue_with_id(pointer(name), UInt64(resid))

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -7,11 +7,20 @@
 export name, id, add_atom!, residue_for_atom
 
 """
-Create a new residue with the given ``name`` and an optional residue identifier
+Create a new residue with the given ``name``
 ``resid``.
 """
-function Residue(name::String, resid::Integer=typemax(UInt64))
-    handle = lib.chfl_residue(pointer(name), UInt64(resid))
+function Residue(name::String)
+    handle = lib.chfl_residue(pointer(name))
+    return Residue(handle)
+end
+
+"""
+Create a new residue with the given ``name`` and residue identifier
+``resid``.
+"""
+function Residue(name::String, resid::Integer)
+    handle = lib.chfl_residue_with_id(pointer(name), UInt64(resid))
     return Residue(handle)
 end
 

--- a/src/Selection.jl
+++ b/src/Selection.jl
@@ -46,7 +46,7 @@ function evaluate(selection::Selection, frame::Frame)
         lib.chfl_selection_evaluate(selection.handle, frame.handle, matching)
     )
     matching = matching[]
-    matches = Array{lib.chfl_match_t}(matching)
+    matches = Array{lib.chfl_match}(matching)
     check(
         lib.chfl_selection_matches(selection.handle, pointer(matches), matching)
     )

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -4,8 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-export remove!, isbond, isangle, isdihedral, bonds_count, angles_count, dihedrals_count,
-    bonds, angles, dihedrals, add_bond!, remove_bond!, add_residue!, residues,
+export remove!, bonds_count, angles_count, dihedrals_count, impropers_count,
+    bonds, angles, dihedrals, impropers, add_bond!, remove_bond!, add_residue!, residues,
     are_linked, count_residues
 
 """
@@ -58,39 +58,6 @@ function remove!(topology::Topology, index::Integer)
 end
 
 """
-Check if the atoms ``i`` and ``j`` are bonded together.
-"""
-function isbond(topology::Topology, i::Integer, j::Integer)
-    result = Ref{UInt8}(0)
-    check(
-        lib.chfl_topology_isbond(topology.handle, UInt64(i), UInt64(j), result)
-    )
-    return convert(Bool, result[])
-end
-
-"""
-Check if the atoms ``i``, ``j`` and ``k`` constitues an angle.
-"""
-function isangle(topology::Topology, i::Integer, j::Integer, k::Integer)
-    result = Ref{UInt8}(0)
-    check(
-        lib.chfl_topology_isangle(topology.handle, UInt64(i), UInt64(j), UInt64(k), result)
-    )
-    return convert(Bool, result[])
-end
-
-"""
-Check if the atoms ``i``, ``j``, ``k`` and ``m`` constitues a dihedral angle.
-"""
-function isdihedral(topology::Topology, i::Integer, j::Integer, k::Integer, m::Integer)
-    result = Ref{UInt8}(0)
-    check(
-        lib.chfl_topology_isdihedral(topology.handle, UInt64(i), UInt64(j), UInt64(k), UInt64(m), result)
-    )
-    return convert(Bool, result[])
-end
-
-"""
 Get the number of bonds in the ``topology``.
 """
 function bonds_count(topology::Topology)
@@ -119,6 +86,17 @@ function dihedrals_count(topology::Topology)
     n = Ref{UInt64}(0)
     check(
         lib.chfl_topology_dihedrals_count(topology.handle, n)
+    )
+    return n[]
+end
+
+"""
+Get the number of improper angles in the ``topology``.
+"""
+function impropers_count(topology::Topology)
+    n = Ref{UInt64}(0)
+    check(
+        lib.chfl_topology_impropers_count(topology.handle, n)
     )
     return n[]
 end
@@ -156,6 +134,19 @@ function dihedrals(topology::Topology)
     result = Array{UInt64}(4, count)
     check(
         lib.chfl_topology_dihedrals(topology.handle, pointer(result), count)
+    )
+    return result
+end
+
+"""
+Get the improper angles in the ``topology``, in a ``4 x impropers_count(topology)``
+array.
+"""
+function impropers(topology::Topology)
+    count = impropers_count(topology)
+    result = Array{UInt64}(4, count)
+    check(
+        lib.chfl_topology_impropers(topology.handle, pointer(result), count)
     )
     return result
 end

--- a/src/UnitCell.jl
+++ b/src/UnitCell.jl
@@ -27,6 +27,8 @@ type CellShape
     end
 end
 
+Base.:(==)(x::CellShape, y::CellShape) = x.value == y.value
+
 const ORTHORHOMBIC = CellShape(lib.CHFL_CELL_ORTHORHOMBIC)
 const TRICLINIC = CellShape(lib.CHFL_CELL_TRICLINIC)
 const INFINITE = CellShape(lib.CHFL_CELL_INFINITE)

--- a/src/UnitCell.jl
+++ b/src/UnitCell.jl
@@ -14,11 +14,11 @@ The possible shape for an unit cell are:
 - ``Chemfiles.TRICLINIC`` for unit cell where the three angles may not be 90°
 - ``Chemfiles.INFINITE`` for unit cells without boundaries
 """
-immutable CellShape
-    value::lib.chfl_cell_shape_t
+type CellShape
+    value::lib.chfl_cellshape
 
     function CellShape(value)
-        value = lib.chfl_cell_shape_t(value)
+        value = lib.chfl_cellshape(value)
         if value in [lib.CHFL_CELL_INFINITE, lib.CHFL_CELL_ORTHORHOMBIC, lib.CHFL_CELL_TRICLINIC]
             return new(value)
         else
@@ -141,7 +141,7 @@ end
 Get the ``cell`` shape, as a ``CellShape`` value
 """
 function shape(cell::UnitCell)
-    result = Ref{lib.chfl_cell_shape_t}(0)
+    result = Ref{lib.chfl_cellshape}(0)
     check(
         lib.chfl_cell_shape(cell.handle, result)
     )

--- a/src/generated/cdef.jl
+++ b/src/generated/cdef.jl
@@ -11,497 +11,617 @@
 # This file contains Julia interface to the C API
 # =========================================================================== #
 
-# Function 'chfl_version' at types.h:135
+# Function 'chfl_version' at types.h:145
 function chfl_version()
     ccall((:chfl_version, libchemfiles), Ptr{UInt8}, (), )
 end
 
-# Function 'chfl_last_error' at errors.h:20
+# Function 'chfl_last_error' at misc.h:19
 function chfl_last_error()
     ccall((:chfl_last_error, libchemfiles), Ptr{UInt8}, (), )
 end
 
-# Function 'chfl_clear_errors' at errors.h:27
+# Function 'chfl_clear_errors' at misc.h:29
 function chfl_clear_errors()
     ccall((:chfl_clear_errors, libchemfiles), chfl_status, (), )
 end
 
-# Function 'chfl_set_warning_callback' at errors.h:36
+# Function 'chfl_set_warning_callback' at misc.h:38
 function chfl_set_warning_callback(callback::Ptr{Void})
     ccall((:chfl_set_warning_callback, libchemfiles), chfl_status, (Ptr{Void},), callback)
 end
 
-# Function 'chfl_atom' at atom.h:24
+# Function 'chfl_add_configuration' at misc.h:53
+function chfl_add_configuration(path::Ptr{UInt8})
+    ccall((:chfl_add_configuration, libchemfiles), chfl_status, (Ptr{UInt8},), path)
+end
+
+# Function 'chfl_property_bool' at property.h:32
+function chfl_property_bool(value::Cbool)
+    ccall((:chfl_property_bool, libchemfiles), Ptr{CHFL_PROPERTY}, (Cbool,), value)
+end
+
+# Function 'chfl_property_double' at property.h:42
+function chfl_property_double(value::Cdouble)
+    ccall((:chfl_property_double, libchemfiles), Ptr{CHFL_PROPERTY}, (Cdouble,), value)
+end
+
+# Function 'chfl_property_string' at property.h:52
+function chfl_property_string(value::Ptr{UInt8})
+    ccall((:chfl_property_string, libchemfiles), Ptr{CHFL_PROPERTY}, (Ptr{UInt8},), value)
+end
+
+# Function 'chfl_property_vector3d' at property.h:62
+function chfl_property_vector3d(value::chfl_vector3d)
+    ccall((:chfl_property_vector3d, libchemfiles), Ptr{CHFL_PROPERTY}, (Ptr{Float64},), value)
+end
+
+# Function 'chfl_property_get_kind' at property.h:69
+function chfl_property_get_kind(property::Ptr{CHFL_PROPERTY}, kind::Ref{chfl_property_kind})
+    ccall((:chfl_property_get_kind, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY}, Ref{chfl_property_kind}), property, kind)
+end
+
+# Function 'chfl_property_get_bool' at property.h:82
+function chfl_property_get_bool(property::Ptr{CHFL_PROPERTY}, value::Ref{Cbool})
+    ccall((:chfl_property_get_bool, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY}, Ref{Cbool}), property, value)
+end
+
+# Function 'chfl_property_get_double' at property.h:95
+function chfl_property_get_double(property::Ptr{CHFL_PROPERTY}, value::Ref{Cdouble})
+    ccall((:chfl_property_get_double, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY}, Ref{Cdouble}), property, value)
+end
+
+# Function 'chfl_property_get_string' at property.h:110
+function chfl_property_get_string(property::Ptr{CHFL_PROPERTY}, buffer::Ptr{UInt8}, buffsize::UInt64)
+    ccall((:chfl_property_get_string, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY}, Ptr{UInt8}, UInt64), property, buffer, buffsize)
+end
+
+# Function 'chfl_property_get_vector3d' at property.h:123
+function chfl_property_get_vector3d(property::Ptr{CHFL_PROPERTY}, value::chfl_vector3d)
+    ccall((:chfl_property_get_vector3d, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY}, Ptr{Float64}), property, value)
+end
+
+# Function 'chfl_property_free' at property.h:131
+function chfl_property_free(property::Ptr{CHFL_PROPERTY})
+    ccall((:chfl_property_free, libchemfiles), chfl_status, (Ptr{CHFL_PROPERTY},), property)
+end
+
+# Function 'chfl_atom' at atom.h:20
 function chfl_atom(name::Ptr{UInt8})
     ccall((:chfl_atom, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{UInt8},), name)
 end
 
-# Function 'chfl_atom_copy' at atom.h:34
+# Function 'chfl_atom_copy' at atom.h:30
 function chfl_atom_copy(atom::Ptr{CHFL_ATOM})
     ccall((:chfl_atom_copy, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{CHFL_ATOM},), atom)
 end
 
-# Function 'chfl_atom_from_frame' at atom.h:44
-function chfl_atom_from_frame(frame::Ptr{CHFL_FRAME}, i::UInt64)
-    ccall((:chfl_atom_from_frame, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{CHFL_FRAME}, UInt64), frame, i)
+# Function 'chfl_atom_from_frame' at atom.h:42
+function chfl_atom_from_frame(frame::Ptr{CHFL_FRAME}, index::UInt64)
+    ccall((:chfl_atom_from_frame, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{CHFL_FRAME}, UInt64), frame, index)
 end
 
-# Function 'chfl_atom_from_topology' at atom.h:56
-function chfl_atom_from_topology(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64)
-    ccall((:chfl_atom_from_topology, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, i)
+# Function 'chfl_atom_from_topology' at atom.h:53
+function chfl_atom_from_topology(topology::Ptr{CHFL_TOPOLOGY}, index::UInt64)
+    ccall((:chfl_atom_from_topology, libchemfiles), Ptr{CHFL_ATOM}, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, index)
 end
 
-# Function 'chfl_atom_mass' at atom.h:67
+# Function 'chfl_atom_mass' at atom.h:64
 function chfl_atom_mass(atom::Ptr{CHFL_ATOM}, mass::Ref{Cdouble})
     ccall((:chfl_atom_mass, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{Cdouble}), atom, mass)
 end
 
-# Function 'chfl_atom_set_mass' at atom.h:78
+# Function 'chfl_atom_set_mass' at atom.h:73
 function chfl_atom_set_mass(atom::Ptr{CHFL_ATOM}, mass::Cdouble)
     ccall((:chfl_atom_set_mass, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Cdouble), atom, mass)
 end
 
-# Function 'chfl_atom_charge' at atom.h:89
+# Function 'chfl_atom_charge' at atom.h:82
 function chfl_atom_charge(atom::Ptr{CHFL_ATOM}, charge::Ref{Cdouble})
     ccall((:chfl_atom_charge, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{Cdouble}), atom, charge)
 end
 
-# Function 'chfl_atom_set_charge' at atom.h:100
+# Function 'chfl_atom_set_charge' at atom.h:91
 function chfl_atom_set_charge(atom::Ptr{CHFL_ATOM}, charge::Cdouble)
     ccall((:chfl_atom_set_charge, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Cdouble), atom, charge)
 end
 
-# Function 'chfl_atom_type' at atom.h:110
+# Function 'chfl_atom_type' at atom.h:101
 function chfl_atom_type(atom::Ptr{CHFL_ATOM}, typ::Ptr{UInt8}, buffsize::UInt64)
     ccall((:chfl_atom_type, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}, UInt64), atom, typ, buffsize)
 end
 
-# Function 'chfl_atom_set_type' at atom.h:121
+# Function 'chfl_atom_set_type' at atom.h:112
 function chfl_atom_set_type(atom::Ptr{CHFL_ATOM}, typ::Ptr{UInt8})
     ccall((:chfl_atom_set_type, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}), atom, typ)
 end
 
-# Function 'chfl_atom_name' at atom.h:133
+# Function 'chfl_atom_name' at atom.h:122
 function chfl_atom_name(atom::Ptr{CHFL_ATOM}, name::Ptr{UInt8}, buffsize::UInt64)
     ccall((:chfl_atom_name, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}, UInt64), atom, name, buffsize)
 end
 
-# Function 'chfl_atom_set_name' at atom.h:144
+# Function 'chfl_atom_set_name' at atom.h:133
 function chfl_atom_set_name(atom::Ptr{CHFL_ATOM}, name::Ptr{UInt8})
     ccall((:chfl_atom_set_name, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}), atom, name)
 end
 
-# Function 'chfl_atom_full_name' at atom.h:156
+# Function 'chfl_atom_full_name' at atom.h:143
 function chfl_atom_full_name(atom::Ptr{CHFL_ATOM}, name::Ptr{UInt8}, buffsize::UInt64)
     ccall((:chfl_atom_full_name, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}, UInt64), atom, name, buffsize)
 end
 
-# Function 'chfl_atom_vdw_radius' at atom.h:168
+# Function 'chfl_atom_vdw_radius' at atom.h:155
 function chfl_atom_vdw_radius(atom::Ptr{CHFL_ATOM}, radius::Ref{Cdouble})
     ccall((:chfl_atom_vdw_radius, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{Cdouble}), atom, radius)
 end
 
-# Function 'chfl_atom_covalent_radius' at atom.h:180
+# Function 'chfl_atom_covalent_radius' at atom.h:165
 function chfl_atom_covalent_radius(atom::Ptr{CHFL_ATOM}, radius::Ref{Cdouble})
     ccall((:chfl_atom_covalent_radius, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{Cdouble}), atom, radius)
 end
 
-# Function 'chfl_atom_atomic_number' at atom.h:192
-function chfl_atom_atomic_number(atom::Ptr{CHFL_ATOM}, number::Ref{Int64})
-    ccall((:chfl_atom_atomic_number, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{Int64}), atom, number)
+# Function 'chfl_atom_atomic_number' at atom.h:175
+function chfl_atom_atomic_number(atom::Ptr{CHFL_ATOM}, number::Ref{UInt64})
+    ccall((:chfl_atom_atomic_number, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ref{UInt64}), atom, number)
 end
 
-# Function 'chfl_atom_free' at atom.h:200
+# Function 'chfl_atom_set_property' at atom.h:185
+function chfl_atom_set_property(atom::Ptr{CHFL_ATOM}, name::Ptr{UInt8}, property::Ptr{CHFL_PROPERTY})
+    ccall((:chfl_atom_set_property, libchemfiles), chfl_status, (Ptr{CHFL_ATOM}, Ptr{UInt8}, Ptr{CHFL_PROPERTY}), atom, name, property)
+end
+
+# Function 'chfl_atom_get_property' at atom.h:199
+function chfl_atom_get_property(atom::Ptr{CHFL_ATOM}, name::Ptr{UInt8})
+    ccall((:chfl_atom_get_property, libchemfiles), Ptr{CHFL_PROPERTY}, (Ptr{CHFL_ATOM}, Ptr{UInt8}), atom, name)
+end
+
+# Function 'chfl_atom_free' at atom.h:207
 function chfl_atom_free(atom::Ptr{CHFL_ATOM})
     ccall((:chfl_atom_free, libchemfiles), chfl_status, (Ptr{CHFL_ATOM},), atom)
 end
 
-# Function 'chfl_residue' at residue.h:26
-function chfl_residue(name::Ptr{UInt8}, resid::UInt64)
-    ccall((:chfl_residue, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{UInt8}, UInt64), name, resid)
+# Function 'chfl_residue' at residue.h:20
+function chfl_residue(name::Ptr{UInt8})
+    ccall((:chfl_residue, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{UInt8},), name)
 end
 
-# Function 'chfl_residue_from_topology' at residue.h:42
+# Function 'chfl_residue_with_id' at residue.h:30
+function chfl_residue_with_id(name::Ptr{UInt8}, resid::UInt64)
+    ccall((:chfl_residue_with_id, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{UInt8}, UInt64), name, resid)
+end
+
+# Function 'chfl_residue_from_topology' at residue.h:46
 function chfl_residue_from_topology(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64)
     ccall((:chfl_residue_from_topology, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, i)
 end
 
-# Function 'chfl_residue_for_atom' at residue.h:58
+# Function 'chfl_residue_for_atom' at residue.h:62
 function chfl_residue_for_atom(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64)
     ccall((:chfl_residue_for_atom, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, i)
 end
 
-# Function 'chfl_residue_copy' at residue.h:70
+# Function 'chfl_residue_copy' at residue.h:74
 function chfl_residue_copy(residue::Ptr{CHFL_RESIDUE})
     ccall((:chfl_residue_copy, libchemfiles), Ptr{CHFL_RESIDUE}, (Ptr{CHFL_RESIDUE},), residue)
 end
 
-# Function 'chfl_residue_atoms_count' at residue.h:77
+# Function 'chfl_residue_atoms_count' at residue.h:81
 function chfl_residue_atoms_count(residue::Ptr{CHFL_RESIDUE}, size::Ref{UInt64})
     ccall((:chfl_residue_atoms_count, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, Ref{UInt64}), residue, size)
 end
 
-# Function 'chfl_residue_id' at residue.h:87
+# Function 'chfl_residue_atoms' at residue.h:95
+function chfl_residue_atoms(residue::Ptr{CHFL_RESIDUE}, atoms::Ptr{UInt64}, natoms::UInt64)
+    ccall((:chfl_residue_atoms, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, Ptr{UInt64}, UInt64), residue, atoms, natoms)
+end
+
+# Function 'chfl_residue_id' at residue.h:108
 function chfl_residue_id(residue::Ptr{CHFL_RESIDUE}, id::Ref{UInt64})
     ccall((:chfl_residue_id, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, Ref{UInt64}), residue, id)
 end
 
-# Function 'chfl_residue_name' at residue.h:99
+# Function 'chfl_residue_name' at residue.h:120
 function chfl_residue_name(residue::Ptr{CHFL_RESIDUE}, name::Ptr{UInt8}, buffsize::UInt64)
     ccall((:chfl_residue_name, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, Ptr{UInt8}, UInt64), residue, name, buffsize)
 end
 
-# Function 'chfl_residue_add_atom' at residue.h:108
+# Function 'chfl_residue_add_atom' at residue.h:129
 function chfl_residue_add_atom(residue::Ptr{CHFL_RESIDUE}, i::UInt64)
     ccall((:chfl_residue_add_atom, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, UInt64), residue, i)
 end
 
-# Function 'chfl_residue_contains' at residue.h:118
+# Function 'chfl_residue_contains' at residue.h:139
 function chfl_residue_contains(residue::Ptr{CHFL_RESIDUE}, i::UInt64, result::Ref{Cbool})
     ccall((:chfl_residue_contains, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE}, UInt64, Ref{Cbool}), residue, i, result)
 end
 
-# Function 'chfl_residue_free' at residue.h:126
+# Function 'chfl_residue_free' at residue.h:147
 function chfl_residue_free(residue::Ptr{CHFL_RESIDUE})
     ccall((:chfl_residue_free, libchemfiles), chfl_status, (Ptr{CHFL_RESIDUE},), residue)
 end
 
-# Function 'chfl_topology' at topology.h:24
+# Function 'chfl_topology' at topology.h:20
 function chfl_topology()
     ccall((:chfl_topology, libchemfiles), Ptr{CHFL_TOPOLOGY}, (), )
 end
 
-# Function 'chfl_topology_from_frame' at topology.h:34
+# Function 'chfl_topology_from_frame' at topology.h:30
 function chfl_topology_from_frame(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_topology_from_frame, libchemfiles), Ptr{CHFL_TOPOLOGY}, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_topology_copy' at topology.h:46
+# Function 'chfl_topology_copy' at topology.h:40
 function chfl_topology_copy(topology::Ptr{CHFL_TOPOLOGY})
     ccall((:chfl_topology_copy, libchemfiles), Ptr{CHFL_TOPOLOGY}, (Ptr{CHFL_TOPOLOGY},), topology)
 end
 
-# Function 'chfl_topology_atoms_count' at topology.h:54
-function chfl_topology_atoms_count(topology::Ptr{CHFL_TOPOLOGY}, natoms::Ref{UInt64})
-    ccall((:chfl_topology_atoms_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, natoms)
+# Function 'chfl_topology_atoms_count' at topology.h:48
+function chfl_topology_atoms_count(topology::Ptr{CHFL_TOPOLOGY}, size::Ref{UInt64})
+    ccall((:chfl_topology_atoms_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, size)
 end
 
-# Function 'chfl_topology_resize' at topology.h:66
+# Function 'chfl_topology_resize' at topology.h:60
 function chfl_topology_resize(topology::Ptr{CHFL_TOPOLOGY}, natoms::UInt64)
     ccall((:chfl_topology_resize, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, natoms)
 end
 
-# Function 'chfl_topology_add_atom' at topology.h:75
+# Function 'chfl_topology_add_atom' at topology.h:67
 function chfl_topology_add_atom(topology::Ptr{CHFL_TOPOLOGY}, atom::Ptr{CHFL_ATOM})
     ccall((:chfl_topology_add_atom, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{CHFL_ATOM}), topology, atom)
 end
 
-# Function 'chfl_topology_remove' at topology.h:86
+# Function 'chfl_topology_remove' at topology.h:78
 function chfl_topology_remove(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64)
     ccall((:chfl_topology_remove, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64), topology, i)
 end
 
-# Function 'chfl_topology_isbond' at topology.h:96
-function chfl_topology_isbond(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64, j::UInt64, result::Ref{Cbool})
-    ccall((:chfl_topology_isbond, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64, UInt64, Ref{Cbool}), topology, i, j, result)
-end
-
-# Function 'chfl_topology_isangle' at topology.h:106
-function chfl_topology_isangle(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64, j::UInt64, k::UInt64, result::Ref{Cbool})
-    ccall((:chfl_topology_isangle, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64, UInt64, UInt64, Ref{Cbool}), topology, i, j, k, result)
-end
-
-# Function 'chfl_topology_isdihedral' at topology.h:120
-function chfl_topology_isdihedral(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64, j::UInt64, k::UInt64, m::UInt64, result::Ref{Cbool})
-    ccall((:chfl_topology_isdihedral, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64, UInt64, UInt64, UInt64, Ref{Cbool}), topology, i, j, k, m, result)
-end
-
-# Function 'chfl_topology_bonds_count' at topology.h:134
+# Function 'chfl_topology_bonds_count' at topology.h:87
 function chfl_topology_bonds_count(topology::Ptr{CHFL_TOPOLOGY}, nbonds::Ref{UInt64})
     ccall((:chfl_topology_bonds_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, nbonds)
 end
 
-# Function 'chfl_topology_angles_count' at topology.h:143
+# Function 'chfl_topology_angles_count' at topology.h:96
 function chfl_topology_angles_count(topology::Ptr{CHFL_TOPOLOGY}, nangles::Ref{UInt64})
     ccall((:chfl_topology_angles_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, nangles)
 end
 
-# Function 'chfl_topology_dihedrals_count' at topology.h:152
+# Function 'chfl_topology_dihedrals_count' at topology.h:105
 function chfl_topology_dihedrals_count(topology::Ptr{CHFL_TOPOLOGY}, ndihedrals::Ref{UInt64})
     ccall((:chfl_topology_dihedrals_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, ndihedrals)
 end
 
-# Function 'chfl_topology_bonds' at topology.h:165
+# Function 'chfl_topology_impropers_count' at topology.h:114
+function chfl_topology_impropers_count(topology::Ptr{CHFL_TOPOLOGY}, nimpropers::Ref{UInt64})
+    ccall((:chfl_topology_impropers_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, nimpropers)
+end
+
+# Function 'chfl_topology_bonds' at topology.h:127
 function chfl_topology_bonds(topology::Ptr{CHFL_TOPOLOGY}, data::Ptr{UInt64}, nbonds::UInt64)
     ccall((:chfl_topology_bonds, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{UInt64}, UInt64), topology, data, nbonds)
 end
 
-# Function 'chfl_topology_angles' at topology.h:178
+# Function 'chfl_topology_angles' at topology.h:140
 function chfl_topology_angles(topology::Ptr{CHFL_TOPOLOGY}, data::Ptr{UInt64}, nangles::UInt64)
     ccall((:chfl_topology_angles, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{UInt64}, UInt64), topology, data, nangles)
 end
 
-# Function 'chfl_topology_dihedrals' at topology.h:191
+# Function 'chfl_topology_dihedrals' at topology.h:154
 function chfl_topology_dihedrals(topology::Ptr{CHFL_TOPOLOGY}, data::Ptr{UInt64}, ndihedrals::UInt64)
     ccall((:chfl_topology_dihedrals, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{UInt64}, UInt64), topology, data, ndihedrals)
 end
 
-# Function 'chfl_topology_add_bond' at topology.h:200
+# Function 'chfl_topology_impropers' at topology.h:168
+function chfl_topology_impropers(topology::Ptr{CHFL_TOPOLOGY}, data::Ptr{UInt64}, nimpropers::UInt64)
+    ccall((:chfl_topology_impropers, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{UInt64}, UInt64), topology, data, nimpropers)
+end
+
+# Function 'chfl_topology_add_bond' at topology.h:177
 function chfl_topology_add_bond(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64, j::UInt64)
     ccall((:chfl_topology_add_bond, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64, UInt64), topology, i, j)
 end
 
-# Function 'chfl_topology_remove_bond' at topology.h:212
+# Function 'chfl_topology_remove_bond' at topology.h:189
 function chfl_topology_remove_bond(topology::Ptr{CHFL_TOPOLOGY}, i::UInt64, j::UInt64)
     ccall((:chfl_topology_remove_bond, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, UInt64, UInt64), topology, i, j)
 end
 
-# Function 'chfl_topology_residues_count' at topology.h:222
-function chfl_topology_residues_count(topology::Ptr{CHFL_TOPOLOGY}, nresidues::Ref{UInt64})
-    ccall((:chfl_topology_residues_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, nresidues)
+# Function 'chfl_topology_residues_count' at topology.h:199
+function chfl_topology_residues_count(topology::Ptr{CHFL_TOPOLOGY}, residues::Ref{UInt64})
+    ccall((:chfl_topology_residues_count, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ref{UInt64}), topology, residues)
 end
 
-# Function 'chfl_topology_add_residue' at topology.h:234
+# Function 'chfl_topology_add_residue' at topology.h:211
 function chfl_topology_add_residue(topology::Ptr{CHFL_TOPOLOGY}, residue::Ptr{CHFL_RESIDUE})
     ccall((:chfl_topology_add_residue, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{CHFL_RESIDUE}), topology, residue)
 end
 
-# Function 'chfl_topology_residues_linked' at topology.h:245
+# Function 'chfl_topology_residues_linked' at topology.h:222
 function chfl_topology_residues_linked(topology::Ptr{CHFL_TOPOLOGY}, first::Ptr{CHFL_RESIDUE}, second::Ptr{CHFL_RESIDUE}, result::Ref{Cbool})
     ccall((:chfl_topology_residues_linked, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY}, Ptr{CHFL_RESIDUE}, Ptr{CHFL_RESIDUE}, Ref{Cbool}), topology, first, second, result)
 end
 
-# Function 'chfl_topology_free' at topology.h:256
+# Function 'chfl_topology_free' at topology.h:233
 function chfl_topology_free(topology::Ptr{CHFL_TOPOLOGY})
     ccall((:chfl_topology_free, libchemfiles), chfl_status, (Ptr{CHFL_TOPOLOGY},), topology)
 end
 
-# Function 'chfl_cell' at cell.h:37
-function chfl_cell(lenghts::chfl_vector_t)
-    ccall((:chfl_cell, libchemfiles), Ptr{CHFL_CELL}, (Ptr{Float64},), lenghts)
+# Function 'chfl_cell' at cell.h:33
+function chfl_cell(lengths::chfl_vector3d)
+    ccall((:chfl_cell, libchemfiles), Ptr{CHFL_CELL}, (Ptr{Float64},), lengths)
 end
 
-# Function 'chfl_cell_triclinic' at cell.h:54
-function chfl_cell_triclinic(lenghts::chfl_vector_t, angles::chfl_vector_t)
-    ccall((:chfl_cell_triclinic, libchemfiles), Ptr{CHFL_CELL}, (Ptr{Float64}, Ptr{Float64}), lenghts, angles)
+# Function 'chfl_cell_triclinic' at cell.h:50
+function chfl_cell_triclinic(lengths::chfl_vector3d, angles::chfl_vector3d)
+    ccall((:chfl_cell_triclinic, libchemfiles), Ptr{CHFL_CELL}, (Ptr{Float64}, Ptr{Float64}), lengths, angles)
 end
 
-# Function 'chfl_cell_from_frame' at cell.h:66
+# Function 'chfl_cell_from_frame' at cell.h:62
 function chfl_cell_from_frame(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_cell_from_frame, libchemfiles), Ptr{CHFL_CELL}, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_cell_copy' at cell.h:76
+# Function 'chfl_cell_copy' at cell.h:72
 function chfl_cell_copy(cell::Ptr{CHFL_CELL})
     ccall((:chfl_cell_copy, libchemfiles), Ptr{CHFL_CELL}, (Ptr{CHFL_CELL},), cell)
 end
 
-# Function 'chfl_cell_volume' at cell.h:83
+# Function 'chfl_cell_volume' at cell.h:79
 function chfl_cell_volume(cell::Ptr{CHFL_CELL}, volume::Ref{Cdouble})
     ccall((:chfl_cell_volume, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ref{Cdouble}), cell, volume)
 end
 
-# Function 'chfl_cell_lengths' at cell.h:92
-function chfl_cell_lengths(cell::Ptr{CHFL_CELL}, lengths::chfl_vector_t)
+# Function 'chfl_cell_lengths' at cell.h:88
+function chfl_cell_lengths(cell::Ptr{CHFL_CELL}, lengths::chfl_vector3d)
     ccall((:chfl_cell_lengths, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, lengths)
 end
 
-# Function 'chfl_cell_set_lengths' at cell.h:103
-function chfl_cell_set_lengths(cell::Ptr{CHFL_CELL}, lenghts::chfl_vector_t)
-    ccall((:chfl_cell_set_lengths, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, lenghts)
+# Function 'chfl_cell_set_lengths' at cell.h:99
+function chfl_cell_set_lengths(cell::Ptr{CHFL_CELL}, lengths::chfl_vector3d)
+    ccall((:chfl_cell_set_lengths, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, lengths)
 end
 
-# Function 'chfl_cell_angles' at cell.h:112
-function chfl_cell_angles(cell::Ptr{CHFL_CELL}, angles::chfl_vector_t)
+# Function 'chfl_cell_angles' at cell.h:108
+function chfl_cell_angles(cell::Ptr{CHFL_CELL}, angles::chfl_vector3d)
     ccall((:chfl_cell_angles, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, angles)
 end
 
-# Function 'chfl_cell_set_angles' at cell.h:125
-function chfl_cell_set_angles(cell::Ptr{CHFL_CELL}, angles::chfl_vector_t)
+# Function 'chfl_cell_set_angles' at cell.h:121
+function chfl_cell_set_angles(cell::Ptr{CHFL_CELL}, angles::chfl_vector3d)
     ccall((:chfl_cell_set_angles, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, angles)
 end
 
-# Function 'chfl_cell_matrix' at cell.h:143
-function chfl_cell_matrix(cell::Ptr{CHFL_CELL}, matrix::Ptr{Float64})
-    ccall((:chfl_cell_matrix, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, matrix)
+# Function 'chfl_cell_matrix' at cell.h:139
+function chfl_cell_matrix(cell::Ptr{CHFL_CELL}, matrix::Ptr{Cdouble})
+    ccall((:chfl_cell_matrix, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Cdouble}), cell, matrix)
 end
 
-# Function 'chfl_cell_shape' at cell.h:152
-function chfl_cell_shape(cell::Ptr{CHFL_CELL}, shape::Ref{chfl_cell_shape_t})
-    ccall((:chfl_cell_shape, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ref{chfl_cell_shape_t}), cell, shape)
+# Function 'chfl_cell_shape' at cell.h:148
+function chfl_cell_shape(cell::Ptr{CHFL_CELL}, shape::Ref{chfl_cellshape})
+    ccall((:chfl_cell_shape, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ref{chfl_cellshape}), cell, shape)
 end
 
-# Function 'chfl_cell_set_shape' at cell.h:161
-function chfl_cell_set_shape(cell::Ptr{CHFL_CELL}, shape::chfl_cell_shape_t)
-    ccall((:chfl_cell_set_shape, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, chfl_cell_shape_t), cell, shape)
+# Function 'chfl_cell_set_shape' at cell.h:157
+function chfl_cell_set_shape(cell::Ptr{CHFL_CELL}, shape::chfl_cellshape)
+    ccall((:chfl_cell_set_shape, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, chfl_cellshape), cell, shape)
 end
 
-# Function 'chfl_cell_free' at cell.h:169
+# Function 'chfl_cell_wrap' at cell.h:166
+function chfl_cell_wrap(cell::Ptr{CHFL_CELL}, vector::chfl_vector3d)
+    ccall((:chfl_cell_wrap, libchemfiles), chfl_status, (Ptr{CHFL_CELL}, Ptr{Float64}), cell, vector)
+end
+
+# Function 'chfl_cell_free' at cell.h:174
 function chfl_cell_free(cell::Ptr{CHFL_CELL})
     ccall((:chfl_cell_free, libchemfiles), chfl_status, (Ptr{CHFL_CELL},), cell)
 end
 
-# Function 'chfl_frame' at frame.h:24
+# Function 'chfl_frame' at frame.h:20
 function chfl_frame()
     ccall((:chfl_frame, libchemfiles), Ptr{CHFL_FRAME}, (), )
 end
 
-# Function 'chfl_frame_copy' at frame.h:34
+# Function 'chfl_frame_copy' at frame.h:30
 function chfl_frame_copy(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_frame_copy, libchemfiles), Ptr{CHFL_FRAME}, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_frame_atoms_count' at frame.h:42
-function chfl_frame_atoms_count(frame::Ptr{CHFL_FRAME}, natoms::Ref{UInt64})
-    ccall((:chfl_frame_atoms_count, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{UInt64}), frame, natoms)
+# Function 'chfl_frame_atoms_count' at frame.h:38
+function chfl_frame_atoms_count(frame::Ptr{CHFL_FRAME}, size::Ref{UInt64})
+    ccall((:chfl_frame_atoms_count, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{UInt64}), frame, size)
 end
 
-# Function 'chfl_frame_positions' at frame.h:60
-function chfl_frame_positions(frame::Ptr{CHFL_FRAME}, positions::Ref{Ptr{Float64}}, size::Ref{UInt64})
-    ccall((:chfl_frame_positions, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{Ptr{Float64}}, Ref{UInt64}), frame, positions, size)
+# Function 'chfl_frame_positions' at frame.h:57
+function chfl_frame_positions(frame::Ptr{CHFL_FRAME}, positions::Ref{Ptr{Cdouble}}, size::Ref{UInt64})
+    ccall((:chfl_frame_positions, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{Ptr{Cdouble}}, Ref{UInt64}), frame, positions, size)
 end
 
-# Function 'chfl_frame_velocities' at frame.h:82
-function chfl_frame_velocities(frame::Ptr{CHFL_FRAME}, velocities::Ref{Ptr{Float64}}, size::Ref{UInt64})
-    ccall((:chfl_frame_velocities, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{Ptr{Float64}}, Ref{UInt64}), frame, velocities, size)
+# Function 'chfl_frame_velocities' at frame.h:80
+function chfl_frame_velocities(frame::Ptr{CHFL_FRAME}, velocities::Ref{Ptr{Cdouble}}, size::Ref{UInt64})
+    ccall((:chfl_frame_velocities, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{Ptr{Cdouble}}, Ref{UInt64}), frame, velocities, size)
 end
 
-# Function 'chfl_frame_add_atom' at frame.h:94
-function chfl_frame_add_atom(frame::Ptr{CHFL_FRAME}, atom::Ptr{CHFL_ATOM}, position::chfl_vector_t, velocity::chfl_vector_t)
+# Function 'chfl_frame_add_atom' at frame.h:92
+function chfl_frame_add_atom(frame::Ptr{CHFL_FRAME}, atom::Ptr{CHFL_ATOM}, position::chfl_vector3d, velocity::chfl_vector3d)
     ccall((:chfl_frame_add_atom, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ptr{CHFL_ATOM}, Ptr{Float64}, Ptr{Float64}), frame, atom, position, velocity)
 end
 
-# Function 'chfl_frame_remove' at frame.h:107
+# Function 'chfl_frame_remove' at frame.h:105
 function chfl_frame_remove(frame::Ptr{CHFL_FRAME}, i::UInt64)
     ccall((:chfl_frame_remove, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64), frame, i)
 end
 
-# Function 'chfl_frame_resize' at frame.h:119
-function chfl_frame_resize(frame::Ptr{CHFL_FRAME}, natoms::UInt64)
-    ccall((:chfl_frame_resize, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64), frame, natoms)
+# Function 'chfl_frame_resize' at frame.h:117
+function chfl_frame_resize(frame::Ptr{CHFL_FRAME}, size::UInt64)
+    ccall((:chfl_frame_resize, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64), frame, size)
 end
 
-# Function 'chfl_frame_add_velocities' at frame.h:131
+# Function 'chfl_frame_add_velocities' at frame.h:129
 function chfl_frame_add_velocities(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_frame_add_velocities, libchemfiles), chfl_status, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_frame_has_velocities' at frame.h:139
+# Function 'chfl_frame_has_velocities' at frame.h:137
 function chfl_frame_has_velocities(frame::Ptr{CHFL_FRAME}, has_velocities::Ref{Cbool})
     ccall((:chfl_frame_has_velocities, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{Cbool}), frame, has_velocities)
 end
 
-# Function 'chfl_frame_set_cell' at frame.h:148
+# Function 'chfl_frame_set_cell' at frame.h:146
 function chfl_frame_set_cell(frame::Ptr{CHFL_FRAME}, cell::Ptr{CHFL_CELL})
     ccall((:chfl_frame_set_cell, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ptr{CHFL_CELL}), frame, cell)
 end
 
-# Function 'chfl_frame_set_topology' at frame.h:160
+# Function 'chfl_frame_set_topology' at frame.h:158
 function chfl_frame_set_topology(frame::Ptr{CHFL_FRAME}, topology::Ptr{CHFL_TOPOLOGY})
     ccall((:chfl_frame_set_topology, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ptr{CHFL_TOPOLOGY}), frame, topology)
 end
 
-# Function 'chfl_frame_step' at frame.h:170
+# Function 'chfl_frame_step' at frame.h:168
 function chfl_frame_step(frame::Ptr{CHFL_FRAME}, step::Ref{UInt64})
     ccall((:chfl_frame_step, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ref{UInt64}), frame, step)
 end
 
-# Function 'chfl_frame_set_step' at frame.h:179
+# Function 'chfl_frame_set_step' at frame.h:177
 function chfl_frame_set_step(frame::Ptr{CHFL_FRAME}, step::UInt64)
     ccall((:chfl_frame_set_step, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64), frame, step)
 end
 
-# Function 'chfl_frame_guess_topology' at frame.h:191
+# Function 'chfl_frame_guess_topology' at frame.h:189
 function chfl_frame_guess_topology(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_frame_guess_topology, libchemfiles), chfl_status, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_frame_free' at frame.h:197
+# Function 'chfl_frame_distance' at frame.h:198
+function chfl_frame_distance(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64, distance::Ref{Cdouble})
+    ccall((:chfl_frame_distance, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64, Ref{Cdouble}), frame, i, j, distance)
+end
+
+# Function 'chfl_frame_angle' at frame.h:209
+function chfl_frame_angle(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64, k::UInt64, angle::Ref{Cdouble})
+    ccall((:chfl_frame_angle, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64, UInt64, Ref{Cdouble}), frame, i, j, k, angle)
+end
+
+# Function 'chfl_frame_dihedral' at frame.h:220
+function chfl_frame_dihedral(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64, k::UInt64, m::UInt64, dihedral::Ref{Cdouble})
+    ccall((:chfl_frame_dihedral, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64, UInt64, UInt64, Ref{Cdouble}), frame, i, j, k, m, dihedral)
+end
+
+# Function 'chfl_frame_out_of_plane' at frame.h:234
+function chfl_frame_out_of_plane(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64, k::UInt64, m::UInt64, distance::Ref{Cdouble})
+    ccall((:chfl_frame_out_of_plane, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64, UInt64, UInt64, Ref{Cdouble}), frame, i, j, k, m, distance)
+end
+
+# Function 'chfl_frame_set_property' at frame.h:246
+function chfl_frame_set_property(frame::Ptr{CHFL_FRAME}, name::Ptr{UInt8}, property::Ptr{CHFL_PROPERTY})
+    ccall((:chfl_frame_set_property, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ptr{UInt8}, Ptr{CHFL_PROPERTY}), frame, name, property)
+end
+
+# Function 'chfl_frame_get_property' at frame.h:260
+function chfl_frame_get_property(frame::Ptr{CHFL_FRAME}, name::Ptr{UInt8})
+    ccall((:chfl_frame_get_property, libchemfiles), Ptr{CHFL_PROPERTY}, (Ptr{CHFL_FRAME}, Ptr{UInt8}), frame, name)
+end
+
+# Function 'chfl_frame_add_bond' at frame.h:269
+function chfl_frame_add_bond(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64)
+    ccall((:chfl_frame_add_bond, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64), frame, i, j)
+end
+
+# Function 'chfl_frame_remove_bond' at frame.h:281
+function chfl_frame_remove_bond(frame::Ptr{CHFL_FRAME}, i::UInt64, j::UInt64)
+    ccall((:chfl_frame_remove_bond, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, UInt64, UInt64), frame, i, j)
+end
+
+# Function 'chfl_frame_add_residue' at frame.h:293
+function chfl_frame_add_residue(frame::Ptr{CHFL_FRAME}, residue::Ptr{CHFL_RESIDUE})
+    ccall((:chfl_frame_add_residue, libchemfiles), chfl_status, (Ptr{CHFL_FRAME}, Ptr{CHFL_RESIDUE}), frame, residue)
+end
+
+# Function 'chfl_frame_free' at frame.h:301
 function chfl_frame_free(frame::Ptr{CHFL_FRAME})
     ccall((:chfl_frame_free, libchemfiles), chfl_status, (Ptr{CHFL_FRAME},), frame)
 end
 
-# Function 'chfl_trajectory_open' at trajectory.h:26
+# Function 'chfl_trajectory_open' at trajectory.h:22
 function chfl_trajectory_open(path::Ptr{UInt8}, mode::Cchar)
     ccall((:chfl_trajectory_open, libchemfiles), Ptr{CHFL_TRAJECTORY}, (Ptr{UInt8}, Cchar), path, mode)
 end
 
-# Function 'chfl_trajectory_with_format' at trajectory.h:42
+# Function 'chfl_trajectory_with_format' at trajectory.h:39
 function chfl_trajectory_with_format(path::Ptr{UInt8}, mode::Cchar, format::Ptr{UInt8})
     ccall((:chfl_trajectory_with_format, libchemfiles), Ptr{CHFL_TRAJECTORY}, (Ptr{UInt8}, Cchar, Ptr{UInt8}), path, mode, format)
 end
 
-# Function 'chfl_trajectory_read' at trajectory.h:54
+# Function 'chfl_trajectory_read' at trajectory.h:51
 function chfl_trajectory_read(trajectory::Ptr{CHFL_TRAJECTORY}, frame::Ptr{CHFL_FRAME})
     ccall((:chfl_trajectory_read, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ptr{CHFL_FRAME}), trajectory, frame)
 end
 
-# Function 'chfl_trajectory_read_step' at trajectory.h:66
+# Function 'chfl_trajectory_read_step' at trajectory.h:63
 function chfl_trajectory_read_step(trajectory::Ptr{CHFL_TRAJECTORY}, step::UInt64, frame::Ptr{CHFL_FRAME})
     ccall((:chfl_trajectory_read_step, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, UInt64, Ptr{CHFL_FRAME}), trajectory, step, frame)
 end
 
-# Function 'chfl_trajectory_write' at trajectory.h:75
+# Function 'chfl_trajectory_write' at trajectory.h:72
 function chfl_trajectory_write(trajectory::Ptr{CHFL_TRAJECTORY}, frame::Ptr{CHFL_FRAME})
     ccall((:chfl_trajectory_write, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ptr{CHFL_FRAME}), trajectory, frame)
 end
 
-# Function 'chfl_trajectory_set_topology' at trajectory.h:86
+# Function 'chfl_trajectory_set_topology' at trajectory.h:83
 function chfl_trajectory_set_topology(trajectory::Ptr{CHFL_TRAJECTORY}, topology::Ptr{CHFL_TOPOLOGY})
     ccall((:chfl_trajectory_set_topology, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ptr{CHFL_TOPOLOGY}), trajectory, topology)
 end
 
-# Function 'chfl_trajectory_topology_file' at trajectory.h:100
+# Function 'chfl_trajectory_topology_file' at trajectory.h:97
 function chfl_trajectory_topology_file(trajectory::Ptr{CHFL_TRAJECTORY}, path::Ptr{UInt8}, format::Ptr{UInt8})
     ccall((:chfl_trajectory_topology_file, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ptr{UInt8}, Ptr{UInt8}), trajectory, path, format)
 end
 
-# Function 'chfl_trajectory_set_cell' at trajectory.h:110
+# Function 'chfl_trajectory_set_cell' at trajectory.h:107
 function chfl_trajectory_set_cell(trajectory::Ptr{CHFL_TRAJECTORY}, cell::Ptr{CHFL_CELL})
     ccall((:chfl_trajectory_set_cell, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ptr{CHFL_CELL}), trajectory, cell)
 end
 
-# Function 'chfl_trajectory_nsteps' at trajectory.h:120
+# Function 'chfl_trajectory_nsteps' at trajectory.h:117
 function chfl_trajectory_nsteps(trajectory::Ptr{CHFL_TRAJECTORY}, nsteps::Ref{UInt64})
     ccall((:chfl_trajectory_nsteps, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY}, Ref{UInt64}), trajectory, nsteps)
 end
 
-# Function 'chfl_trajectory_close' at trajectory.h:131
+# Function 'chfl_trajectory_close' at trajectory.h:128
 function chfl_trajectory_close(trajectory::Ptr{CHFL_TRAJECTORY})
     ccall((:chfl_trajectory_close, libchemfiles), chfl_status, (Ptr{CHFL_TRAJECTORY},), trajectory)
 end
 
-# Function 'chfl_selection' at selection.h:24
+# Function 'chfl_selection' at selection.h:20
 function chfl_selection(selection::Ptr{UInt8})
     ccall((:chfl_selection, libchemfiles), Ptr{CHFL_SELECTION}, (Ptr{UInt8},), selection)
 end
 
-# Function 'chfl_selection_copy' at selection.h:37
+# Function 'chfl_selection_copy' at selection.h:33
 function chfl_selection_copy(selection::Ptr{CHFL_SELECTION})
     ccall((:chfl_selection_copy, libchemfiles), Ptr{CHFL_SELECTION}, (Ptr{CHFL_SELECTION},), selection)
 end
 
-# Function 'chfl_selection_size' at selection.h:49
+# Function 'chfl_selection_size' at selection.h:45
 function chfl_selection_size(selection::Ptr{CHFL_SELECTION}, size::Ref{UInt64})
     ccall((:chfl_selection_size, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ref{UInt64}), selection, size)
 end
 
-# Function 'chfl_selection_string' at selection.h:62
+# Function 'chfl_selection_string' at selection.h:58
 function chfl_selection_string(selection::Ptr{CHFL_SELECTION}, string::Ptr{UInt8}, buffsize::UInt64)
     ccall((:chfl_selection_string, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ptr{UInt8}, UInt64), selection, string, buffsize)
 end
 
-# Function 'chfl_selection_evaluate' at selection.h:75
-function chfl_selection_evaluate(selection::Ptr{CHFL_SELECTION}, frame::Ptr{CHFL_FRAME}, nmatches::Ref{UInt64})
-    ccall((:chfl_selection_evaluate, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ptr{CHFL_FRAME}, Ref{UInt64}), selection, frame, nmatches)
+# Function 'chfl_selection_evaluate' at selection.h:71
+function chfl_selection_evaluate(selection::Ptr{CHFL_SELECTION}, frame::Ptr{CHFL_FRAME}, n_matches::Ref{UInt64})
+    ccall((:chfl_selection_evaluate, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ptr{CHFL_FRAME}, Ref{UInt64}), selection, frame, n_matches)
 end
 
-# Function 'chfl_selection_matches' at selection.h:101
-function chfl_selection_matches(selection::Ptr{CHFL_SELECTION}, matches::Ptr{chfl_match_t}, nmatches::UInt64)
-    ccall((:chfl_selection_matches, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ptr{chfl_match_t}, UInt64), selection, matches, nmatches)
+# Function 'chfl_selection_matches' at selection.h:97
+function chfl_selection_matches(selection::Ptr{CHFL_SELECTION}, matches::Ptr{chfl_match}, n_matches::UInt64)
+    ccall((:chfl_selection_matches, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION}, Ptr{chfl_match}, UInt64), selection, matches, n_matches)
 end
 
-# Function 'chfl_selection_free' at selection.h:109
+# Function 'chfl_selection_free' at selection.h:105
 function chfl_selection_free(selection::Ptr{CHFL_SELECTION})
     ccall((:chfl_selection_free, libchemfiles), chfl_status, (Ptr{CHFL_SELECTION},), selection)
 end

--- a/src/generated/types.jl
+++ b/src/generated/types.jl
@@ -24,21 +24,21 @@ const Cbool = Cuchar
 const chfl_vector3d = Array{Cdouble, 1}
 # === End of manual translation
 
-struct CHFL_TRAJECTORY end
+immutable CHFL_TRAJECTORY end
 
-struct CHFL_CELL end
+immutable CHFL_CELL end
 
-struct CHFL_ATOM end
+immutable CHFL_ATOM end
 
-struct CHFL_FRAME end
+immutable CHFL_FRAME end
 
-struct CHFL_TOPOLOGY end
+immutable CHFL_TOPOLOGY end
 
-struct CHFL_SELECTION end
+immutable CHFL_SELECTION end
 
-struct CHFL_RESIDUE end
+immutable CHFL_RESIDUE end
 
-struct CHFL_PROPERTY end
+immutable CHFL_PROPERTY end
 
 # enum chfl_status
 const chfl_status = UInt32

--- a/src/generated/types.jl
+++ b/src/generated/types.jl
@@ -24,21 +24,21 @@ const Cbool = Cuchar
 const chfl_vector3d = Array{Cdouble, 1}
 # === End of manual translation
 
-immutable CHFL_TRAJECTORY end
+struct CHFL_TRAJECTORY end
 
-immutable CHFL_CELL end
+struct CHFL_CELL end
 
-immutable CHFL_ATOM end
+struct CHFL_ATOM end
 
-immutable CHFL_FRAME end
+struct CHFL_FRAME end
 
-immutable CHFL_TOPOLOGY end
+struct CHFL_TOPOLOGY end
 
-immutable CHFL_SELECTION end
+struct CHFL_SELECTION end
 
-immutable CHFL_RESIDUE end
+struct CHFL_RESIDUE end
 
-immutable CHFL_PROPERTY end
+struct CHFL_PROPERTY end
 
 # enum chfl_status
 const chfl_status = UInt32

--- a/src/generated/types.jl
+++ b/src/generated/types.jl
@@ -12,7 +12,7 @@
 # =========================================================================== #
 
 # === Manually translated from the header
-immutable chfl_match_t
+struct chfl_match
     size    ::UInt64
     atoms_1 ::UInt64
     atoms_2 ::UInt64
@@ -21,22 +21,24 @@ immutable chfl_match_t
 end
 
 const Cbool = Cuchar
-const chfl_vector_t = Array{Cdouble, 1}
+const chfl_vector3d = Array{Cdouble, 1}
 # === End of manual translation
 
-immutable CHFL_TRAJECTORY end
+struct CHFL_TRAJECTORY end
 
-immutable CHFL_CELL end
+struct CHFL_CELL end
 
-immutable CHFL_ATOM end
+struct CHFL_ATOM end
 
-immutable CHFL_FRAME end
+struct CHFL_FRAME end
 
-immutable CHFL_TOPOLOGY end
+struct CHFL_TOPOLOGY end
 
-immutable CHFL_SELECTION end
+struct CHFL_SELECTION end
 
-immutable CHFL_RESIDUE end
+struct CHFL_RESIDUE end
+
+struct CHFL_PROPERTY end
 
 # enum chfl_status
 const chfl_status = UInt32
@@ -45,11 +47,21 @@ const CHFL_MEMORY_ERROR = chfl_status(1)
 const CHFL_FILE_ERROR = chfl_status(2)
 const CHFL_FORMAT_ERROR = chfl_status(3)
 const CHFL_SELECTION_ERROR = chfl_status(4)
-const CHFL_GENERIC_ERROR = chfl_status(5)
-const CHFL_CXX_ERROR = chfl_status(6)
+const CHFL_CONFIGURATION_ERROR = chfl_status(5)
+const CHFL_OUT_OF_BOUNDS = chfl_status(6)
+const CHFL_PROPERTY_ERROR = chfl_status(7)
+const CHFL_GENERIC_ERROR = chfl_status(254)
+const CHFL_CXX_ERROR = chfl_status(255)
 
-# enum chfl_cell_shape_t
-const chfl_cell_shape_t = UInt32
-const CHFL_CELL_ORTHORHOMBIC = chfl_cell_shape_t(0)
-const CHFL_CELL_TRICLINIC = chfl_cell_shape_t(1)
-const CHFL_CELL_INFINITE = chfl_cell_shape_t(2)
+# enum chfl_property_kind
+const chfl_property_kind = UInt32
+const CHFL_PROPERTY_BOOL = chfl_property_kind(0)
+const CHFL_PROPERTY_DOUBLE = chfl_property_kind(1)
+const CHFL_PROPERTY_STRING = chfl_property_kind(2)
+const CHFL_PROPERTY_VECTOR3D = chfl_property_kind(3)
+
+# enum chfl_cellshape
+const chfl_cellshape = UInt32
+const CHFL_CELL_ORTHORHOMBIC = chfl_cellshape(0)
+const CHFL_CELL_TRICLINIC = chfl_cellshape(1)
+const CHFL_CELL_INFINITE = chfl_cellshape(2)

--- a/test/Atom.jl
+++ b/test/Atom.jl
@@ -1,7 +1,7 @@
 @testset "Atom Type" begin
     atom = Atom("He")
 
-    @test_approx_eq_eps mass(atom) 4.002602 1e-6
+    @test mass(atom) ≈ 4.002602 atol=1e-6
     @test charge(atom) == 0
     @test name(atom) == "He"
     @test atom_type(atom) == "He"
@@ -18,8 +18,8 @@
     @test atom_type(atom) == "Zn"
     @test fullname(atom) == "Zinc"
 
-    @test_approx_eq_eps vdw_radius(atom) 2.1 1e-1
-    @test_approx_eq_eps covalent_radius(atom) 1.31 1e-2
+    @test vdw_radius(atom) ≈ 2.1 atol=1e-1
+    @test covalent_radius(atom) ≈ 1.31 atol=1e-2
     @test atomic_number(atom) == 30
 
     copy = deepcopy(atom)

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -69,7 +69,7 @@
         add_atom!(angle_frame, Atom(""), [1.0,0.0,0.0])
         add_atom!(angle_frame, Atom(""), [0.0,0.0,0.0])
         add_atom!(angle_frame, Atom(""), [0.0,1.0,0.0])
-        @test bend(angle_frame, 0, 1, 2) ≈ pi/2 atol=1e-10
+        @test angle(angle_frame, 0, 1, 2) ≈ pi/2 atol=1e-10
 
         dihedral_frame = Frame()
         add_atom!(dihedral_frame, Atom(""), [1.0,0.0,0.0])

--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -1,4 +1,4 @@
-@testset "Frame Type" begin
+@testset "Frame type" begin
     frame = Frame()
     @test size(frame) == 0
 
@@ -58,4 +58,62 @@
     resize!(copy, 10)
     @test size(copy) == 10
     @test size(frame) == 4
+
+    @testset "Geometry tests" begin
+        distance_frame = Frame()
+        add_atom!(distance_frame, Atom(""), [0.0,0.0,0.0])
+        add_atom!(distance_frame, Atom(""), [1.0,2.0,3.0])
+        @test distance(distance_frame, 0, 1) ≈ sqrt(14.0) atol=1e-10
+
+        angle_frame = Frame()
+        add_atom!(angle_frame, Atom(""), [1.0,0.0,0.0])
+        add_atom!(angle_frame, Atom(""), [0.0,0.0,0.0])
+        add_atom!(angle_frame, Atom(""), [0.0,1.0,0.0])
+        @test bend(angle_frame, 0, 1, 2) ≈ pi/2 atol=1e-10
+
+        dihedral_frame = Frame()
+        add_atom!(dihedral_frame, Atom(""), [1.0,0.0,0.0])
+        add_atom!(dihedral_frame, Atom(""), [0.0,0.0,0.0])
+        add_atom!(dihedral_frame, Atom(""), [0.0,1.0,0.0])
+        add_atom!(dihedral_frame, Atom(""), [0.0,1.0,1.0])
+        @test dihedral(dihedral_frame, 0, 1, 2, 3) ≈ pi/2 atol=1e-10
+
+        oop_frame = Frame()
+        add_atom!(oop_frame, Atom(""), [0.0,0.0,0.0])
+        add_atom!(oop_frame, Atom(""), [0.0,0.0,2.0])
+        add_atom!(oop_frame, Atom(""), [1.0,0.0,0.0])
+        add_atom!(oop_frame, Atom(""), [0.0,1.0,0.0])
+        @test out_of_plane(oop_frame, 0, 1, 2, 3) ≈ 2 atol=1e-10
+    end
+
+    @testset "Frame add/remove bonds" begin
+        frame = Frame();
+        add_atom!(frame, Atom("H"), [1.0, 0.0, 0.0])
+        add_atom!(frame, Atom("O"), [0.0, 0.0, 0.0])
+        add_atom!(frame, Atom("H"), [0.0, 1.0, 0.0])
+
+        add_bond!(frame, 0, 1)
+        add_bond!(frame, 1, 2)
+
+        # the bonds are actually stored inside the topology
+        @test bonds(Topology(frame)) == reshape(UInt64[0,1, 1,2], (2,2))
+        # angles are automaticaly computed too
+        @test angles(Topology(frame)) == reshape(UInt64[0, 1, 2], (3,1))
+
+        remove_bond!(frame, 1, 0)
+        @test bonds(Topology(frame)) == reshape(UInt64[1,2], (2,1))
+    end
+
+    @testset "Frame add residues" begin
+        frame = Frame()
+        add_atom!(frame, Atom("Zn"), [0.0, 0.0, 0.0])
+        add_atom!(frame, Atom("Fe"), [1.0, 2.0, 3.0])
+
+        residue = Residue("first")
+        add_atom!(residue,0)
+        add_residue!(frame,residue)
+
+        # residues are actually stored in the topology
+        @test count_residues(Topology(frame)) == 1
+    end
 end

--- a/test/Property.jl
+++ b/test/Property.jl
@@ -1,38 +1,16 @@
 @testset "Property type" begin
-    prop = Property(false)
-    @test kind(prop).value == Chemfiles.PROPERTY_BOOL.value
-    @test get_bool(prop) == false
-    @test_throws ChemfilesError get_double(prop)
-    @test_throws ChemfilesError get_string(prop)
-    @test_throws ChemfilesError get_vector3d(prop)
-
     atom = Atom("")
-    set_property!(atom, "test", prop)
-    @test get_bool(get_property(atom, "test")) == false
-
-    prop = Property(1234.567)
-    @test kind(prop).value == Chemfiles.PROPERTY_DOUBLE.value
-    @test get_double(prop) == 1234.567
-    @test_throws ChemfilesError get_bool(prop)
-    @test_throws ChemfilesError get_string(prop)
-    @test_throws ChemfilesError get_vector3d(prop)
+    set_property!(atom, "test", false)
+    @test property(atom, "test") == false
 
     frame = Frame()
-    set_property!(frame, "test", prop)
-    @test get_double(get_property(frame, "test")) == 1234.567
+    set_property!(frame, "test", 1234.567)
+    @test property(frame, "test") == 1234.567
 
-    prop = Property("TESTINGTESTING")
-    @test kind(prop).value == Chemfiles.PROPERTY_STRING.value
-    @test get_string(prop) == "TESTINGTESTING"
-    @test_throws ChemfilesError get_double(prop)
-    @test_throws ChemfilesError get_bool(prop)
-    @test_throws ChemfilesError get_vector3d(prop)
+    set_property!(atom,"test2", "TESTINGTESTING")
+    @test property(atom, "test2") == "TESTINGTESTING"
 
-    prop = Property([1.0,2.0,3.0])
-    @test kind(prop).value == Chemfiles.PROPERTY_VECTOR3D.value
-    @test get_vector3d(prop) == [1.0,2.0,3.0]
-    @test_throws ChemfilesError get_double(prop)
-    @test_throws ChemfilesError get_string(prop)
-    @test_throws ChemfilesError get_bool(prop)
+    set_property!(frame, "test2", [1.0,2.0,3.0])
+    @test property(frame, "test2") == [1.0,2.0,3.0]
 
 end

--- a/test/Property.jl
+++ b/test/Property.jl
@@ -1,0 +1,38 @@
+@testset "Property type" begin
+    prop = Property(false)
+    @test kind(prop).value == Chemfiles.PROPERTY_BOOL.value
+    @test get_bool(prop) == false
+    @test_throws ChemfilesError get_double(prop)
+    @test_throws ChemfilesError get_string(prop)
+    @test_throws ChemfilesError get_vector3d(prop)
+
+    atom = Atom("")
+    set_property!(atom, "test", prop)
+    @test get_bool(get_property(atom, "test")) == false
+
+    prop = Property(1234.567)
+    @test kind(prop).value == Chemfiles.PROPERTY_DOUBLE.value
+    @test get_double(prop) == 1234.567
+    @test_throws ChemfilesError get_bool(prop)
+    @test_throws ChemfilesError get_string(prop)
+    @test_throws ChemfilesError get_vector3d(prop)
+
+    frame = Frame()
+    set_property!(frame, "test", prop)
+    @test get_double(get_property(frame, "test")) == 1234.567
+
+    prop = Property("TESTINGTESTING")
+    @test kind(prop).value == Chemfiles.PROPERTY_STRING.value
+    @test get_string(prop) == "TESTINGTESTING"
+    @test_throws ChemfilesError get_double(prop)
+    @test_throws ChemfilesError get_bool(prop)
+    @test_throws ChemfilesError get_vector3d(prop)
+
+    prop = Property([1.0,2.0,3.0])
+    @test kind(prop).value == Chemfiles.PROPERTY_VECTOR3D.value
+    @test get_vector3d(prop) == [1.0,2.0,3.0]
+    @test_throws ChemfilesError get_double(prop)
+    @test_throws ChemfilesError get_string(prop)
+    @test_throws ChemfilesError get_bool(prop)
+
+end

--- a/test/Residue.jl
+++ b/test/Residue.jl
@@ -5,7 +5,7 @@
 
     residue = Residue("GUA")
     @test name(residue) == "GUA"
-    @test id(residue) == typemax(UInt64)
+    @test_throws ChemfilesError id(residue)
 
     @test size(residue) == 0
     add_atom!(residue, 0);

--- a/test/Topology.jl
+++ b/test/Topology.jl
@@ -21,13 +21,6 @@
     @test angles_count(topology) == 2
     @test dihedrals_count(topology) == 1
 
-    @test isbond(topology, 0, 1) == true
-    @test isbond(topology, 0, 3) == false
-    @test isangle(topology, 0, 1, 2) == true
-    @test isangle(topology, 0, 1, 3) == false
-    @test isdihedral(topology, 0, 1, 2, 3) == true
-    @test isdihedral(topology, 0, 1, 3, 2) == false
-
     top_bonds = reshape(UInt64[0, 1,   1, 2,   2, 3], (2, 3))
 
     @test bonds(topology) == top_bonds
@@ -81,5 +74,20 @@
 
         add_bond!(topology, 6, 9)
         @test are_linked(topology, first, second) == true
+    end
+
+    @testset "Impropers" begin
+        topology = Topology()
+        add_atom!(topology, Atom("N"))
+        add_atom!(topology, Atom("H"))
+        add_atom!(topology, Atom("H"))
+        add_atom!(topology, Atom("H"))
+
+        add_bond!(topology, 0, 1)
+        add_bond!(topology, 0, 2)
+        add_bond!(topology, 0, 3)
+
+        @test impropers_count(topology) == 1
+        @test impropers(topology) == reshape(UInt64[1, 0, 2, 3], (4,1))
     end
 end

--- a/test/Trajectory.jl
+++ b/test/Trajectory.jl
@@ -74,10 +74,6 @@ const DATAPATH = joinpath(dirname(@__FILE__), "data")
                               X 4 5 6
                               """
 
-        @static if is_windows()
-            EXPECTED_CONTENT = replace(EXPECTED_CONTENT, "\n", "\r\n")
-        end
-
         frame = Frame()
         resize!(frame, 4)
         pos = positions(frame)
@@ -110,9 +106,7 @@ const DATAPATH = joinpath(dirname(@__FILE__), "data")
         close(trajectory)
         @test isopen(trajectory) == false
 
-        open("test-tmp.xyz") do fd
-            @test readstring(fd) == EXPECTED_CONTENT
-        end
+        @test readstring("test-tmp.xyz") == EXPECTED_CONTENT
 
         rm("test-tmp.xyz")
     end

--- a/test/UnitCell.jl
+++ b/test/UnitCell.jl
@@ -22,10 +22,10 @@
                                0, 0, 30], (3, 3))
     @test cell_matrix(cell) ≈ expected atol=1e-10
 
-    @test shape(cell).value == Chemfiles.ORTHORHOMBIC.value
+    @test shape(cell) == Chemfiles.ORTHORHOMBIC
 
     set_shape!(cell, Chemfiles.TRICLINIC)
-    @test shape(cell).value == Chemfiles.TRICLINIC.value
+    @test shape(cell) == Chemfiles.TRICLINIC
 
     set_angles!(cell, 80, 89, 100)
     @test angles(cell) == [80.0, 89.0, 100.0]

--- a/test/UnitCell.jl
+++ b/test/UnitCell.jl
@@ -20,16 +20,15 @@
     expected = reshape(Float64[10, 0, 0,
                                0, 20, 0,
                                0, 0, 30], (3, 3))
-    @test_approx_eq_eps cell_matrix(cell) expected 1e-10
+    @test cell_matrix(cell) ≈ expected atol=1e-10
 
-    @test shape(cell) == Chemfiles.ORTHORHOMBIC
+    @test shape(cell).value == Chemfiles.ORTHORHOMBIC.value
 
     set_shape!(cell, Chemfiles.TRICLINIC)
-    @test shape(cell) == Chemfiles.TRICLINIC
+    @test shape(cell).value == Chemfiles.TRICLINIC.value
 
     set_angles!(cell, 80, 89, 100)
     @test angles(cell) == [80.0, 89.0, 100.0]
-
 
     copy = deepcopy(cell)
     @test lengths(copy) == [10.0, 20.0, 30.0]

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -14,7 +14,7 @@ end
     @test_throws ChemfilesError Residue(Topology(), 3)
     @test_throws UndefVarError TEST_CALLBACK == false
 
-    @test Chemfiles.last_error() == "Out of bounds residue index 3. Last residue is 0."
+    @test Chemfiles.last_error() == "Residue index out of bounds in topology: we have 0 residues, but the index is 3"
 
     Chemfiles.clear_errors()
     @test Chemfiles.last_error() == ""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,12 @@ using Base.Test
 
 TESTS = [
     "errors.jl", "Atom.jl", "Topology.jl", "UnitCell.jl", "Frame.jl",
-    "Trajectory.jl", "Selection.jl", "Residue.jl"
+    "Trajectory.jl", "Selection.jl", "Residue.jl", "Property.jl"
 ]
 
 function main()
     @testset "Generics" begin
-        @test Chemfiles.version() == "0.7.4"
+        @test Chemfiles.version() == "0.8.0"
     end
     root = dirname(@__FILE__)
     for test in TESTS


### PR DESCRIPTION
The title says it all.

Major changes are:
- Addition of Property type and related PropertyKind type.
- Removal of `isbond`, `isangle`, and `isdihedral` methods from Topology
- Addition of `distance`, `bend`, `dihedral`, and `out_of_plane` methods to Frame to calculate the corresponding value.
- `bend` is used over angle due to a clash with another Julia function.
- Addition of `impropers` to Topology.
- Additional functionality for bonds and residues added to Frame.