### PR TITLE
Add open(f, args...) for Trajectories

### DIFF
--- a/src/Trajectory.jl
+++ b/src/Trajectory.jl
@@ -20,6 +20,19 @@ function Trajectory(path::AbstractString, mode::Char='r', format::AbstractString
 end
 
 """
+Apply the function `f` to the result of `Trajectory(args...)` and close the
+resulting trajectory upon completion, similar to ``open(f, args...)``.
+"""
+function Trajectory(f::Function, args...)
+    tr = Trajectory(args...)
+    try
+        f(tr)
+    finally
+        close(tr)
+    end
+end
+
+"""
 Read the next step of the ``trajectory``, and return the corresponding ``Frame``.
 """
 function Base.read(trajectory::Trajectory)

--- a/test/Trajectory.jl
+++ b/test/Trajectory.jl
@@ -107,4 +107,13 @@ const DATAPATH = joinpath(@__DIR__, "data")
 
         rm("test-tmp.xyz")
     end
+
+    @testset "Function syntax" begin
+        trajectory = nothing
+        Trajectory(joinpath(DATAPATH, "water.xyz")) do tr 
+            trajectory = tr
+            @test isopen(trajectory)
+        end
+        @test !isopen(trajectory)
+    end
 end


### PR DESCRIPTION
This adds the function syntax from [`Base.open`](https://github.com/JuliaLang/julia/blob/2d5741174ce3e6a394010d2e470e4269ca54607f/base/io.jl#L295-L302) to `Trajectory`, allowing trajectories to be accessed without needing to manually close them.