### PR TITLE
Fix for Julia 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
   - 1.0
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 
 script:

--- a/doc/reference/residue.rst
+++ b/doc/reference/residue.rst
@@ -19,7 +19,9 @@
 
 .. jl:autofunction:: src/Residue.jl add_atom!
 
-.. jl:autofunction:: src/Residue.jl contains
+.. jl:function:: contains(residue::Residue, index::Integer)
+
+    Check if the atom at the given ``index`` is in the ``residue``.
 
 .. jl:autofunction:: src/Residue.jl atoms
 

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -1,7 +1,11 @@
 # Chemfiles.jl, a modern library for chemistry file reading and writing
 # Copyright (C) Guillaume Fraux and contributors -- BSD license
 
-export id, residue_for_atom, contains, atoms
+export id, residue_for_atom, atoms
+
+if VERSION < v"1.5.0-alpha"
+    export contains
+end
 
 __ptr(residue::Residue) = __ptr(residue.__handle)
 __const_ptr(residue::Residue) = __const_ptr(residue.__handle)
@@ -88,13 +92,22 @@ function add_atom!(residue::Residue, index::Integer)
     return nothing
 end
 
-"""
-Check if the atom at the given ``index`` is in the ``residue``.
-"""
-function contains(residue::Residue, index::Integer)
+function __contains(residue::Residue, index::Integer)
     result = Ref{UInt8}(0)
     __check(lib.chfl_residue_contains(__const_ptr(residue), UInt64(index), result))
     return convert(Bool, result[])
+end
+
+if VERSION < v"1.5.0-alpha"
+    """
+    Check if the atom at the given ``index`` is in the ``residue``.
+    """
+    contains(residue::Residue, index::Integer) = __contains(residue, index)
+else
+    """
+    Check if the atom at the given ``index`` is in the ``residue``.
+    """
+    Base.contains(residue::Residue, index::Integer) = __contains(residue, index)
 end
 
 """


### PR DESCRIPTION
A new `Base.contains` functions is exported in julia >= 1.5, so we have to conditionally add overload to it.