### PR TITLE
fix: check used function is a substring of other function name

### DIFF
--- a/doc/reference/residue.rst
+++ b/doc/reference/residue.rst
@@ -21,6 +21,8 @@
 
 .. jl:autofunction:: src/Residue.jl contains
 
+.. jl:autofunction:: src/Residue.jl atoms
+
 .. jl:autofunction:: src/Residue.jl deepcopy
 
 .. jl:autofunction:: src/Residue.jl property

--- a/scripts/check_used_functions.py
+++ b/scripts/check_used_functions.py
@@ -5,6 +5,7 @@ effectively used in the chemfiles binding.
 """
 import os
 import sys
+import re
 
 IGNORED = ["chfl_trajectory_open"]
 ERROR = False
@@ -28,26 +29,27 @@ def functions_list():
     return functions
 
 
-def read_all_source():
-    source = ""
+def read_all_binding_functions():
+    binding_functions = set()
     for (dirpath, _, paths) in os.walk(os.path.join(ROOT, "src")):
         for path in paths:
             if path != "cdef.jl" and path.endswith(".jl"):
                 with open(os.path.join(ROOT, dirpath, path)) as fd:
-                    source += fd.read()
-    return source
+                    file_functions = re.findall(r"(chfl_[a-z A-Z 0-9 _]*)\(", fd.read())
+                    binding_functions.update(file_functions)
+    return binding_functions
 
 
-def check_functions(functions, source):
+def check_functions(functions, binding_functions):
     for function in functions:
-        if function not in source and function not in IGNORED:
+        if function not in binding_functions and function not in IGNORED:
             error("Missing: " + function)
 
 
 if __name__ == '__main__':
     functions = functions_list()
-    source = read_all_source()
-    check_functions(functions, source)
+    binding_functions = read_all_binding_functions()
+    check_functions(functions, binding_functions)
 
     if ERROR:
         sys.exit(1)

--- a/scripts/check_used_functions.py
+++ b/scripts/check_used_functions.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python
 """
-Check that all the functions defined in the C API are being used.
+Check that all the functions defined in the C API are
+effectively used in the chemfiles binding.
 """
 import os
 import sys
 
 IGNORED = ["chfl_trajectory_open"]
 ERROR = False
-ROOT = os.path.dirname(os.path.dirname(os.path.abspath((__file__))))
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+
 
 def error(message):
     print(message)
     global ERROR
     ERROR = True
 
-def all_functions():
+
+def functions_list():
     functions = []
     with open(os.path.join(ROOT, "src", "generated", "cdef.jl")) as fd:
         for line in fd:
@@ -24,10 +27,11 @@ def all_functions():
                 functions.append(name)
     return functions
 
+
 def read_all_source():
     source = ""
-    for (dirpath, _, pathes) in os.walk(os.path.join(ROOT, "src")):
-        for path in pathes:
+    for (dirpath, _, paths) in os.walk(os.path.join(ROOT, "src")):
+        for path in paths:
             if path != "cdef.jl" and path.endswith(".jl"):
                 with open(os.path.join(ROOT, dirpath, path)) as fd:
                     source += fd.read()
@@ -41,8 +45,9 @@ def check_functions(functions, source):
 
 
 if __name__ == '__main__':
-    functions = all_functions()
+    functions = functions_list()
     source = read_all_source()
     check_functions(functions, source)
+
     if ERROR:
         sys.exit(1)

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -1,7 +1,7 @@
 # Chemfiles.jl, a modern library for chemistry file reading and writing
 # Copyright (C) Guillaume Fraux and contributors -- BSD license
 
-export id, residue_for_atom, contains
+export id, residue_for_atom, contains, atoms
 
 __ptr(residue::Residue) = __ptr(residue.__handle)
 __const_ptr(residue::Residue) = __const_ptr(residue.__handle)
@@ -95,6 +95,16 @@ function contains(residue::Residue, index::Integer)
     result = Ref{UInt8}(0)
     __check(lib.chfl_residue_contains(__const_ptr(residue), UInt64(index), result))
     return convert(Bool, result[])
+end
+
+"""
+Get the atoms in a ``residue``. This function returns a list of indexes.
+"""
+function atoms(residue::Residue)
+    count = size(residue)
+    result = Array{UInt64}(undef, count)
+    __check(lib.chfl_residue_atoms(__const_ptr(residue), pointer(result), count))
+    return result
 end
 
 """

--- a/test/Residue.jl
+++ b/test/Residue.jl
@@ -21,6 +21,8 @@
 
     @test contains(residue, 56) == true
 
+    @test atoms(residue) == UInt64[0, 30, 56]
+
     topology = Topology()
     @test count_residues(topology) == 0
 


### PR DESCRIPTION
Follow up to https://github.com/chemfiles/chemfiles.rs/pull/13.
I also added the missing `atoms` function for residues. This is effectively my first real experience with Julia, so this could have gone wrong :)