### PR TITLE
Keep a reference to the Frame when returning position/velocities view

### DIFF
--- a/test/Frame.jl
+++ b/test/Frame.jl
@@ -5,6 +5,7 @@
 
         resize!(frame, 4)
         @test size(frame) == 4
+        @test length(frame) == 4
 
         pos = positions(frame)
         expected = Array{Float64}(undef, 3, 4)


### PR DESCRIPTION
This should prevent the GC from removing the frame and the corresponding memory too early.

This fixes #37 for me, over 500 `include`.