### PR TITLE
Remove Compat dependency and up DocStringExtensions bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,13 @@ version = "0.10.2"
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Chemfiles_jll = "78a364fa-1a3c-552a-b4bb-8fa0f9c1fcca"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 BinaryProvider = "0.5.8"
 Chemfiles_jll = "= 0.10.2"
-Compat = "3.15"
-DocStringExtensions = "0.8.3"
+DocStringExtensions = "0.8.3, 0.9"
 julia = "1.0"
 
 [extras]

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -2,7 +2,6 @@
 # Copyright (C) Guillaume Fraux and contributors -- BSD license
 
 module Chemfiles
-    import Compat
     using DocStringExtensions
 
     @template METHODS =

--- a/src/Residue.jl
+++ b/src/Residue.jl
@@ -1,7 +1,13 @@
 # Chemfiles.jl, a modern library for chemistry file reading and writing
 # Copyright (C) Guillaume Fraux and contributors -- BSD license
 
-using Compat: contains
+@static if VERSION < v"1.5.0" # defined here for retro-compatibility
+    contains(haystack::AbstractString, needle) = occursin(needle, haystack)
+    contains(needle) = Base.Fix2(contains, needle)
+else
+    import Base: contains
+end
+
 export id, residue_for_atom, atoms, contains
 
 __ptr(residue::Residue) = __ptr(residue.__handle)
@@ -91,7 +97,7 @@ end
 """
 Check if the atom at the given `index` is in the `residue`.
 """
-function Compat.contains(residue::Residue, index::Integer)
+function contains(residue::Residue, index::Integer)
     result = Ref{UInt8}(0)
     __check(lib.chfl_residue_contains(__const_ptr(residue), UInt64(index), result))
     return convert(Bool, result[])

--- a/src/Topology.jl
+++ b/src/Topology.jl
@@ -11,14 +11,14 @@ __const_ptr(topology::Topology) = __const_ptr(topology.__handle)
 
 """
 Possible bond orders in Chemfiles:
-    - `Chemfiles.UnknownBond`: when the bond order is not specified
-    - `Chemfiles.SingleBond`: for single bonds
-    - `Chemfiles.DoubleBond`: for double bonds
-    - `Chemfiles.TripleBond`: for triple bonds
-    - `Chemfiles.QuadrupleBond`: for quadruple bonds (present in some metals)
-    - `Chemfiles.QuintupletBond`: for qintuplet bonds (present in some metals)
-    - `Chemfiles.AmideBond`: for amide bonds
-    - `Chemfiles.AromaticBond`: for aromatic bonds
+- `Chemfiles.UnknownBond`: when the bond order is not specified
+- `Chemfiles.SingleBond`: for single bonds
+- `Chemfiles.DoubleBond`: for double bonds
+- `Chemfiles.TripleBond`: for triple bonds
+- `Chemfiles.QuadrupleBond`: for quadruple bonds (present in some metals)
+- `Chemfiles.QuintupletBond`: for qintuplet bonds (present in some metals)
+- `Chemfiles.AmideBond`: for amide bonds
+- `Chemfiles.AromaticBond`: for aromatic bonds
 """
 @enum BondOrder begin
     UnknownBond = lib.CHFL_BOND_UNKNOWN


### PR DESCRIPTION
Compat.jl is a somewhat heavy dependency, and it is only used here to add the `contains` function. This PR removes it as a dependency and simply adds `contains` manually (it's only two lines).

Also up the DocStringExtensions.jl compat bound: I did not manually check every single docstring, but I did not see anything weird appear on the ones I checked with DocStringExtensions v0.9. There was an indentation mistake on the docstring of [`BondOrder`](http://chemfiles.org/Chemfiles.jl/latest/reference/topology/#Chemfiles.BondOrder) so that's fixed as well.