### PR TITLE
AtomsBase interface support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Guillaume Fraux <guillaume.fraux@epfl.ch>"]
 version = "0.10.3"
 
 [deps]
+AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Chemfiles_jll = "78a364fa-1a3c-552a-b4bb-8fa0f9c1fcca"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Chemfiles_jll = "78a364fa-1a3c-552a-b4bb-8fa0f9c1fcca"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BinaryProvider = "0.5.8"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Chemfiles_jll = "78a364fa-1a3c-552a-b4bb-8fa0f9c1fcca"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,5 +67,6 @@ makedocs(
         "reference/residue.md",
         "reference/selection.md",
         "reference/misc.md",
+        "reference/atomsbase.md",
     ]
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,5 +46,6 @@ Pages = [
     "reference/residue.md",
     "reference/selection.md",
     "reference/misc.md",
+    "reference/atomsbase.md",
 ]
 ```

--- a/docs/src/reference/atomsbase.md
+++ b/docs/src/reference/atomsbase.md
@@ -1,0 +1,6 @@
+# AtomsBase
+
+```@autodocs
+Modules = [Chemfiles]
+Pages   = ["AtomsBase.jl"]
+```

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -2,7 +2,8 @@
 #export n_dimensions, species_type, atomic_mass, atomic_symbol, atomic_number
 
 #TODO Eigene Markdown Erklärung D:
-#TODO Funktionen für Atom?!
+
+import AtomsBase: velocity
 
 """
     position(frame::Frame)
@@ -21,6 +22,8 @@ function position(frame::Frame)
     return ab_pos
 end
 position(frame::Frame, index) = position(frame)[index] 
+#TODO
+position(atom::Atom) = [0, 0, 0]
 
 """
     velocity(frame::Frame)
@@ -44,6 +47,8 @@ function velocity(frame::Frame)
     end
 end
 velocity(frame::Frame, index) = velocity(frame)[index]
+#TODO
+velocity(atom::Atom) = missing
 
 """
     bounding_box(frame::Frame)
@@ -79,6 +84,7 @@ This function is part of the AtomsBase.jl interface
 Return number of dimensions, which is always 3 for every frame.
 """
 n_dimensions(frame::Frame) = 3
+n_dimensions(atom::Atom) = 3
 
 """
     species_type(frame::Frame)
@@ -100,6 +106,7 @@ the `index`th species in `frame`. The elements are `<: Unitful.Mass`.
 """
 atomic_mass(frame::Frame) = mass.(frame)*u"u"
 atomic_mass(frame::Frame, index) = mass(Atom(frame, index))*u"u"
+atomic_mass(atom::Atom) = mass(atom)*u"u"
 
 """
     atomic_symbol(frame::Frame)
@@ -112,6 +119,9 @@ the `index`th species in `frame`.
 """
 atomic_symbol(frame::Frame) = Symbol.(type.(frame))
 atomic_symbol(frame::Frame, index) = Symbol(type(Atom(frame, index)))
+atomic_symbol(atom::Atom) = Symbol(type(atom))
+
+element(atom::Atom) = elements[atomic_symbol(atom)]
 
 """
     atomic_number(frame::Frame)
@@ -124,3 +134,4 @@ the `index`th species in `frame`.
 """
 atomic_number(frame::Frame) = atomic_number.(frame)
 atomic_number(frame::Frame, index) = atomic_number(Atom(frame, index))
+#atomic_number(atom::Atom) already implemented by Chemfiles

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -1,22 +1,3 @@
-abstract type BoundaryCondition end
-struct DirichletZero <: BoundaryCondition end  # Dirichlet zero boundary (i.e. molecular context)
-struct Periodic <: BoundaryCondition end  # Periodic BCs
-
-bounding_box(frame::Frame) = collect.(eachrow(UnitCell(frame)))
-
-boundary_conditions(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [DirichletZero(), DirichletZero(), DirichletZero()] : [Periodic(), Periodic(), Periodic()] 
-
-#???
-function periodicity end
-
-n_dimensions(frame::Frame) = 3
-
-#???
-function species_type end
-
-#???
-function element end
-
 function position(frame::Frame)
     cf_pos = positions(frame)
     ab_pos = [cf_pos[:,i] for i in 1:size(cf_pos,2)]
@@ -26,19 +7,26 @@ end
 position(frame::Frame, index) = position(frame)[index] 
 
 function velocity(frame::Frame)
-    cf_vel = positions(frame)
+    cf_vel = velocities(frame)
     ab_vel = [cf_vel[:,i] for i in 1:size(cf_vel,2)]
-    return ab_pos
+    return ab_vel
 end
 
 velocity(frame::Frame, index) = velocity(frame)[index]
+
+bounding_box(frame::Frame) = collect.(eachrow(matrix(UnitCell(frame))))
+boundary_conditions(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [DirichletZero(), DirichletZero(), DirichletZero()] : [Periodic(), Periodic(), Periodic()] 
+periodicity(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [false, false, false] : [true, true, true]
+
+n_dimensions(frame::Frame) = 3
+
+species_type(frame::Frame) = Chemfiles.Atom
 
 atomic_mass(frame::Frame) = mass.(frame)
 atomic_mass(frame::Frame, index) = mass(Atom(frame, index))
 
 atomic_symbol(frame::Frame) = Symbol.(type.(frame))
 atomic_symbol(frame::Frame, index) = Symbol(type(Atom(frame, index)))
- 
 
 atomic_number(frame::Frame) = atomic_number.(frame)
 atomic_number(frame::Frame, index) = atomic_number(Atom(frame, index))

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -125,7 +125,7 @@ element(atom::Atom) = elements[atomic_symbol(atom)]
 
 This function is part of the AtomsBase.jl interface
 
-Vector of atomic numbers in the system `frNW` or the atomic number of a particular `aTOM` /
+Vector of atomic numbers in the system `frame` or the atomic number of a particular `Atom` /
 the `index`th species in `frame`.
 """
 atomic_number(frame::Frame) = atomic_number.(frame)

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -1,0 +1,32 @@
+identity(obj) = obj
+
+function position(frame::Frame)
+    cf_pos = positions(frame)
+    ab_pos = [cf_pos[:,i] for i in 1:size(cf_pos,2)]
+    return ab_pos
+end
+
+position(frame::Frame, index) = position(frame)[index] 
+
+function velocity(frame::Frame)
+    cf_vel = positions(frame)
+    ab_vel = [cf_vel[:,i] for i in 1:size(cf_vel,2)]
+    return ab_pos
+end
+
+velocity(frame::Frame, index) = velocity(frame)[index]
+
+function atomic_mass(frame::Frame)
+end
+
+function atomic_mass(frame::Frame, index)
+end
+
+function atomic_symbol(frame::Frame)
+end
+
+function atomic_symbol(frame::Frame, index)
+end
+
+#atomic_number(frame::Frame) = atomic_number.(frame, 0:length(frame)-1)
+atomic_number(frame::Frame, index) = atomic_number(Atom(frame, index))

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -1,9 +1,5 @@
-#export position, velocity, bounding_box, boundary_conditions, periodicity
-#export n_dimensions, species_type, atomic_mass, atomic_symbol, atomic_number
-
-#TODO Eigene Markdown Erklärung D:
-
-import AtomsBase: velocity
+import AtomsBase: velocity, position, bounding_box, boundary_conditions, periodicity
+import AtomsBase: n_dimensions, atomic_mass, atomic_number, atomic_symbol, element
 
 """
     position(frame::Frame)
@@ -22,7 +18,7 @@ function position(frame::Frame)
     return ab_pos
 end
 position(frame::Frame, index) = position(frame)[index] 
-#TODO
+#ISSUE position not saved in Atom 
 position(atom::Atom) = [0, 0, 0]
 
 """
@@ -47,7 +43,7 @@ function velocity(frame::Frame)
     end
 end
 velocity(frame::Frame, index) = velocity(frame)[index]
-#TODO
+#ISSUE velocity not saved in Atom
 velocity(atom::Atom) = missing
 
 """

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -1,32 +1,126 @@
+#export position, velocity, bounding_box, boundary_conditions, periodicity
+#export n_dimensions, species_type, atomic_mass, atomic_symbol, atomic_number
+
+#TODO Eigene Markdown Erklärung D:
+#TODO Funktionen für Atom?!
+
+"""
+    position(frame::Frame)
+    position(frame::Frame, index)
+
+This function is part of the AtomsBase.jl interface
+
+Return a vector of positions of every particle in the system `frame`. Return type
+should be a vector of vectors each containing `3` elements that are
+`<:Unitful.Length`. If an index is passed or the action is on an `Atom`,
+return only the position of the referenced `Atom` on that index.
+"""
 function position(frame::Frame)
     cf_pos = positions(frame)
-    ab_pos = [cf_pos[:,i] for i in 1:size(cf_pos,2)]
+    ab_pos = [cf_pos[:,i] for i in 1:size(cf_pos,2)]*u"Å"
     return ab_pos
 end
-
 position(frame::Frame, index) = position(frame)[index] 
 
-function velocity(frame::Frame)
-    cf_vel = velocities(frame)
-    ab_vel = [cf_vel[:,i] for i in 1:size(cf_vel,2)]
-    return ab_vel
-end
+"""
+    velocity(frame::Frame)
+    velocity(frame::Frame, index)
 
+This function is part of the AtomsBase.jl interface
+
+Return a vector of velocities of every particle in the system `frame`. Return
+type should be a vector of vectors each containing `3` elements that are
+`<:Unitful.Velocity`. If an index is passed or the action is on an `Atom`,
+return only the velocity of the referenced `Atom`. Returned value of the function
+may be `missing`.
+"""
+function velocity(frame::Frame)
+    if has_velocities(frame)
+        cf_vel = velocities(frame)
+        ab_vel = [cf_vel[:,i] for i in 1:size(cf_vel,2)]*u"Å/ps"
+        return ab_vel
+    else
+        return missing
+    end
+end
 velocity(frame::Frame, index) = velocity(frame)[index]
 
-bounding_box(frame::Frame) = collect.(eachrow(matrix(UnitCell(frame))))
+"""
+    bounding_box(frame::Frame)
+
+This function is part of the AtomsBase.jl interface
+
+Return a vector of length `3` of vectors of length `3` that describe the "box" in which the system `frame` is defined.
+"""
+bounding_box(frame::Frame) = collect.(eachrow(matrix(UnitCell(frame))))*u"Å"
+
+"""
+    boundary_conditions(farme::Frame)
+
+This function is part of the AtomsBase.jl interface
+
+Return a vector of length `3` of `BoundaryCondition` objects, one for each direction described by `bounding_box(sys)`.
+"""
 boundary_conditions(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [DirichletZero(), DirichletZero(), DirichletZero()] : [Periodic(), Periodic(), Periodic()] 
+
+"""
+This function is part of the AtomsBase.jl interface
+
+Return vector indicating whether the system is periodic along a dimension.
+"""
 periodicity(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [false, false, false] : [true, true, true]
 
+"""
+    n_dimensions(::AbstractSystem)
+    n_dimensions(atom)
+
+This function is part of the AtomsBase.jl interface
+
+Return number of dimensions, which is always 3 for every frame.
+"""
 n_dimensions(frame::Frame) = 3
 
+"""
+    species_type(frame::Frame)
+
+This function is part of the AtomsBase.jl interface
+
+Return the type used to represent a species or atom, which is always Chemfiles.Atom.
+"""
 species_type(frame::Frame) = Chemfiles.Atom
 
-atomic_mass(frame::Frame) = mass.(frame)
-atomic_mass(frame::Frame, index) = mass(Atom(frame, index))
+"""
+    atomic_mass(frame::Frame)
+    atomic_mass(frame::Frame, index)
 
+This function is part of the AtomsBase.jl interface
+
+Vector of atomic masses in the system `frame` or the atomic mass of a particular `Atom` /
+the `index`th species in `frame`. The elements are `<: Unitful.Mass`.
+"""
+atomic_mass(frame::Frame) = mass.(frame)*u"u"
+atomic_mass(frame::Frame, index) = mass(Atom(frame, index))*u"u"
+
+"""
+    atomic_symbol(frame::Frame)
+    atomic_symbol(frame::Frame, index)
+
+This function is part of the AtomsBase.jl interface
+
+Vector of atomic symbols in the system `sys` or the atomic symbol of a particular `Atom` /
+the `index`th species in `frame`.
+"""
 atomic_symbol(frame::Frame) = Symbol.(type.(frame))
 atomic_symbol(frame::Frame, index) = Symbol(type(Atom(frame, index)))
 
+"""
+    atomic_number(frame::Frame)
+    atomic_number(frame::Frame, index)
+
+This function is part of the AtomsBase.jl interface
+
+Vector of atomic numbers in the system `frNW` or the atomic number of a particular `aTOM` /
+the `index`th species in `frame`.
+"""
 atomic_number(frame::Frame) = atomic_number.(frame)
 atomic_number(frame::Frame, index) = atomic_number(Atom(frame, index))

--- a/src/AtomsBase.jl
+++ b/src/AtomsBase.jl
@@ -1,4 +1,21 @@
-identity(obj) = obj
+abstract type BoundaryCondition end
+struct DirichletZero <: BoundaryCondition end  # Dirichlet zero boundary (i.e. molecular context)
+struct Periodic <: BoundaryCondition end  # Periodic BCs
+
+bounding_box(frame::Frame) = collect.(eachrow(UnitCell(frame)))
+
+boundary_conditions(frame::Frame) = shape(UnitCell(frame)) == Chemfiles.Infinite ? [DirichletZero(), DirichletZero(), DirichletZero()] : [Periodic(), Periodic(), Periodic()] 
+
+#???
+function periodicity end
+
+n_dimensions(frame::Frame) = 3
+
+#???
+function species_type end
+
+#???
+function element end
 
 function position(frame::Frame)
     cf_pos = positions(frame)
@@ -16,17 +33,12 @@ end
 
 velocity(frame::Frame, index) = velocity(frame)[index]
 
-function atomic_mass(frame::Frame)
-end
+atomic_mass(frame::Frame) = mass.(frame)
+atomic_mass(frame::Frame, index) = mass(Atom(frame, index))
 
-function atomic_mass(frame::Frame, index)
-end
+atomic_symbol(frame::Frame) = Symbol.(type.(frame))
+atomic_symbol(frame::Frame, index) = Symbol(type(Atom(frame, index)))
+ 
 
-function atomic_symbol(frame::Frame)
-end
-
-function atomic_symbol(frame::Frame, index)
-end
-
-#atomic_number(frame::Frame) = atomic_number.(frame, 0:length(frame)-1)
+atomic_number(frame::Frame) = atomic_number.(frame)
 atomic_number(frame::Frame, index) = atomic_number(Atom(frame, index))

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -4,6 +4,7 @@
 module Chemfiles
     using DocStringExtensions
     using AtomsBase
+    using Unitful
 
     @template METHODS =
     """

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -130,6 +130,7 @@ module Chemfiles
     include("Frame.jl")
     include("Selection.jl")
     include("Trajectory.jl")
+    include("AtomsBase.jl")
 
     function __init__()
         if !startswith(version(), "0.10")

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -3,6 +3,7 @@
 
 module Chemfiles
     using DocStringExtensions
+    using AtomsBase
 
     @template METHODS =
     """
@@ -86,7 +87,7 @@ module Chemfiles
     - The [`Topology`](@ref) of the system;
     - The [`UnitCell`](@ref) of the system.
     """
-    struct Frame
+    struct Frame <: AbstractSystem{3}
         __handle :: CxxPointer{lib.CHFL_FRAME}
     end
 

--- a/src/Chemfiles.jl
+++ b/src/Chemfiles.jl
@@ -5,6 +5,7 @@ module Chemfiles
     using DocStringExtensions
     using AtomsBase
     using Unitful
+    using PeriodicTable
 
     @template METHODS =
     """

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -1,5 +1,5 @@
 @testset "AtomsBase" begin
-    trajectory = Trajectory(joinpath(DATAPATH, "water.xyz"))
+    trajectory = Trajectory(joinpath(DATAPATH, "Mn3Si.cif"))
     frame = read(trajectory)
 
     @test positions(frame)[:, 1] == Chemfiles.position(frame)[1]
@@ -9,6 +9,7 @@
     @test Chemfiles.atomic_number(frame, 0) == Chemfiles.atomic_number(frame)[1]
     @test Chemfiles.atomic_mass(frame, 0) == Chemfiles.atomic_mass(frame)[1]
     @test Chemfiles.atomic_symbol(frame, 0) == Chemfiles.atomic_symbol(frame)[1]
-    println(Chemfiles.bounding_box(frame))
-    println(Chemfiles.boundary_conditions(frame))
+    @test Chemfiles.bounding_box(frame)[1] == [3.9998697199999995, 0.0, 0.0]
+    @test Chemfiles.boundary_conditions(frame) == [Chemfiles.Periodic(), Chemfiles.Periodic(), Chemfiles.Periodic()]
+    @test Chemfiles.periodicity(frame) == [true, true, true]
 end

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -1,15 +1,16 @@
 @testset "AtomsBase" begin
+
     trajectory = Trajectory(joinpath(DATAPATH, "Mn3Si.cif"))
     frame = read(trajectory)
 
-    @test positions(frame)[:, 1] == Chemfiles.position(frame)[1]
-    @test positions(frame)[:, 1] == Chemfiles.position(frame, 1)
-    @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame)[1]
-    @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame, 1)
+    @test positions(frame)[:, 1]*u"Å" == Chemfiles.position(frame)[1]
+    @test positions(frame)[:, 1]*u"Å" == Chemfiles.position(frame, 1)
+    @test_broken velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame)[1]
+    @test_broken velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame, 1)
     @test Chemfiles.atomic_number(frame, 0) == Chemfiles.atomic_number(frame)[1]
     @test Chemfiles.atomic_mass(frame, 0) == Chemfiles.atomic_mass(frame)[1]
     @test Chemfiles.atomic_symbol(frame, 0) == Chemfiles.atomic_symbol(frame)[1]
-    @test Chemfiles.bounding_box(frame)[1] == [3.9998697199999995, 0.0, 0.0]
+    @test Chemfiles.bounding_box(frame)[1] == [3.9998697199999995, 0.0, 0.0]*u"Å"
     @test Chemfiles.boundary_conditions(frame) == [Chemfiles.Periodic(), Chemfiles.Periodic(), Chemfiles.Periodic()]
     @test Chemfiles.periodicity(frame) == [true, true, true]
 end

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -1,15 +1,17 @@
 @testset "AtomsBase" begin
-
     trajectory = Trajectory(joinpath(DATAPATH, "Mn3Si.cif"))
     frame = read(trajectory)
 
     @test positions(frame)[:, 1]*u"Å" == Chemfiles.position(frame)[1]
     @test positions(frame)[:, 1]*u"Å" == Chemfiles.position(frame, 1)
-    @test_broken velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame)[1]
-    @test_broken velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame, 1)
-    @test Chemfiles.atomic_number(frame, 0) == Chemfiles.atomic_number(frame)[1]
-    @test Chemfiles.atomic_mass(frame, 0) == Chemfiles.atomic_mass(frame)[1]
-    @test Chemfiles.atomic_symbol(frame, 0) == Chemfiles.atomic_symbol(frame)[1]
+    if has_velocities(frame)
+        @test velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame)[1]
+        @test velocities(frame)[:, 1]*u"Å/ps" == Chemfiles.velocity(frame, 1)
+    end
+    @test Chemfiles.atomic_number(frame, 0) == Chemfiles.atomic_number(frame)[1] == Chemfiles.atomic_number(frame[1])
+    @test Chemfiles.atomic_mass(frame, 0) == Chemfiles.atomic_mass(frame)[1] == Chemfiles.atomic_mass(frame[1])
+    @test Chemfiles.atomic_symbol(frame, 0) == Chemfiles.atomic_symbol(frame)[1] == Chemfiles.atomic_symbol(frame[1])
+    #Tests that would need a hardcodedchange if the testcase would be changed
     @test Chemfiles.bounding_box(frame)[1] == [3.9998697199999995, 0.0, 0.0]*u"Å"
     @test Chemfiles.boundary_conditions(frame) == [Chemfiles.Periodic(), Chemfiles.Periodic(), Chemfiles.Periodic()]
     @test Chemfiles.periodicity(frame) == [true, true, true]

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -1,0 +1,11 @@
+@testset "AtomsBase" begin
+    trajectory = Trajectory(joinpath(DATAPATH, "water.xyz"))
+    frame = read(trajectory)
+
+    @test positions(frame)[:, 1] == Chemfiles.position(frame)[1]
+    @test positions(frame)[:, 1] == Chemfiles.position(frame, 1)
+    @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame)[1]
+    @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame, 1)
+    
+    println(Chemfiles.atomic_number.(identity(frame), 1:5))
+end

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -6,6 +6,9 @@
     @test positions(frame)[:, 1] == Chemfiles.position(frame, 1)
     @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame)[1]
     @test_broken velocities(frame)[:, 1] == Chemfiles.velocity(frame, 1)
-    
-    println(Chemfiles.atomic_number.(identity(frame), 1:5))
+    @test Chemfiles.atomic_number(frame, 0) == Chemfiles.atomic_number(frame)[1]
+    @test Chemfiles.atomic_mass(frame, 0) == Chemfiles.atomic_mass(frame)[1]
+    @test Chemfiles.atomic_symbol(frame, 0) == Chemfiles.atomic_symbol(frame)[1]
+    println(Chemfiles.bounding_box(frame))
+    println(Chemfiles.boundary_conditions(frame))
 end

--- a/test/data/Mn3Si.cif
+++ b/test/data/Mn3Si.cif
@@ -1,0 +1,30 @@
+# generated using pymatgen
+data_Mn3Si
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   3.99986972
+_cell_length_b   3.99986972
+_cell_length_c   3.99986972
+_cell_angle_alpha   60.00000000
+_cell_angle_beta   60.00000000
+_cell_angle_gamma   60.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   Mn3Si
+_chemical_formula_sum   'Mn3 Si1'
+_cell_volume   45.25041215
+_cell_formula_units_Z   1
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Mn  Mn0  1  0.25000000  0.25000000  0.25000000  1
+  Mn  Mn1  1  0.75000000  0.75000000  0.75000000  1
+  Mn  Mn2  1  0.50000000  0.50000000  0.50000000  1
+  Si  Si3  1  0.00000000  0.00000000  0.00000000  1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Chemfiles
 using Test
+using Unitful
 
 TESTS = [
     "atom.jl",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ TESTS = [
     "trajectory.jl",
     "selection.jl",
     "misc.jl",
+    "atomsbase.jl",
 ]
 
 include("utils.jl")


### PR DESCRIPTION
Hello,
is there any interest in Chemfiles being compatible with the AtomsBase.jl package? The Frame object holds pretty much the same information an AtomsBase system does.
However, implementig the interface I've noticed two issues.
- function names get quite messy, e.g. Chemfiles uses position(frame::Frame) and AtomsBase positions(frame::Frame)
- The interface requires a function position(atom::Atom), however Chemfiles doesn't store an atoms position in an atom

I understand that accepting this pull request would probably be to messy for the main Chmfiles.jl package, so it would make sense to have a seperate package where most Frame functions are replaced by AtomsBase functions.