### PR TITLE
remove BinaryProvider

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,10 @@ authors = ["Guillaume Fraux <guillaume.fraux@epfl.ch>"]
 version = "0.10.3"
 
 [deps]
-BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 Chemfiles_jll = "78a364fa-1a3c-552a-b4bb-8fa0f9c1fcca"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-BinaryProvider = "0.5.8"
 Chemfiles_jll = "= 0.10.3"
 DocStringExtensions = "0.8.3, 0.9"
 julia = "1.6"


### PR DESCRIPTION
Since this package relies on the Chemfiles_jll artifcat, binary provider is not needed.