### PR TITLE
fix UInt8 type

### DIFF
--- a/src/Trajectory.jl
+++ b/src/Trajectory.jl
@@ -16,7 +16,7 @@ format to use when opening the file.
 """
 function Trajectory(path::AbstractString, mode::Char='r', format::AbstractString="")
     ptr = @__check_ptr(lib.chfl_trajectory_with_format(
-        pointer(path), UInt8(mode), pointer(format),
+        pointer(path), Cchar(mode), pointer(format),
     ))
     return Trajectory(CxxPointer(ptr, is_const=false), nothing)
 end

--- a/src/Trajectory.jl
+++ b/src/Trajectory.jl
@@ -16,7 +16,7 @@ format to use when opening the file.
 """
 function Trajectory(path::AbstractString, mode::Char='r', format::AbstractString="")
     ptr = @__check_ptr(lib.chfl_trajectory_with_format(
-        pointer(path), Int8(mode), pointer(format),
+        pointer(path), UInt8(mode), pointer(format),
     ))
     return Trajectory(CxxPointer(ptr, is_const=false), nothing)
 end


### PR DESCRIPTION
I was getting this error while reading some trajectories:


```
ERROR: MethodError: no method matching chfl_trajectory_with_format(::Ptr{UInt8}, ::Int8, ::Ptr{UInt8})

Closest candidates are:
  chfl_trajectory_with_format(::Ptr{UInt8}, ::UInt8, ::Ptr{UInt8})
   @ Chemfiles ~/.julia/packages/Chemfiles/Wzcgy/src/generated/cdef.jl:608

```

and this change seems to be the fix.